### PR TITLE
Add image scaling

### DIFF
--- a/Source/CDMarkdownImage.swift
+++ b/Source/CDMarkdownImage.swift
@@ -41,6 +41,7 @@ open class CDMarkdownImage: CDMarkdownLinkElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var frame: CGRect?
     
     open var regex: String {
         return CDMarkdownImage.regex
@@ -54,11 +55,13 @@ open class CDMarkdownImage: CDMarkdownLinkElement {
     public init(font: CDFont? = nil,
                 color: CDColor? = CDColor.blue,
                 backgroundColor: CDColor? = nil,
-                paragraphStyle: NSParagraphStyle? = nil) {
+                paragraphStyle: NSParagraphStyle? = nil,
+                fitIn frame: CGRect? = nil) {
         self.font = font
         self.color = color
         self.backgroundColor = backgroundColor
         self.paragraphStyle = paragraphStyle
+        self.frame = frame
     }
     
     open func formatText(_ attributedString: NSMutableAttributedString,
@@ -98,9 +101,11 @@ open class CDMarkdownImage: CDMarkdownLinkElement {
             if let data = data,
                 let image = CDImage(data: data) {
                 textAttachment.image = image
+                adjustAttachmentSize(textAttachment, image: image)
             // Try to load image from local file store
             } else if let image = CDImage(named: url.path) {
                 textAttachment.image = image
+                adjustAttachmentSize(textAttachment, image: image)
             }
         }
         
@@ -126,6 +131,21 @@ open class CDMarkdownImage: CDMarkdownLinkElement {
                             link: String) {
         attributedString.addAttributes(attributes,
                                        range: range)
+    }
+
+    private func adjustAttachmentSize(_ attachment: NSTextAttachment, image: UIImage) {
+        guard let frame = frame else {
+            return
+        }
+
+        // about 10 point padding so the image will fit
+        let preferredWidth = frame.width - 10
+        let widthScalingFactor = image.size.width / preferredWidth
+
+        attachment.bounds = CGRect(x: 0.0,
+                                   y: 0.0,
+                                   width: image.size.width / widthScalingFactor,
+                                   height: image.size.height / widthScalingFactor)
     }
 }
 

--- a/Source/CDMarkdownParser.swift
+++ b/Source/CDMarkdownParser.swift
@@ -75,6 +75,7 @@ open class CDMarkdownParser {
                 backgroundColor: CDColor = CDColor.clear,
                 paragraphStyle: NSParagraphStyle? = nil,
                 automaticLinkDetectionEnabled: Bool = true,
+                fitIn frame: CGRect? = nil,
                 customElements: [CDMarkdownElement] = []) {
         self.font = font
         self.fontColor = fontColor
@@ -99,13 +100,13 @@ open class CDMarkdownParser {
         code = CDMarkdownCode(font: font)
         syntax = CDMarkdownSyntax(font: font)
 #if os(iOS) || os(macOS) || os(tvOS)
-        image = CDMarkdownImage(font: font)
+        image = CDMarkdownImage(font: font, fitIn: frame)
 #endif
         
         self.automaticLinkDetectionEnabled = automaticLinkDetectionEnabled
         self.escapingElements = [codeEscaping, escaping]
 #if os(iOS) || os(macOS) || os(tvOS)
-        self.defaultElements = [header, list, quote, link, automaticLink, bold, italic, image]
+        self.defaultElements = [header, list, quote, image, link, automaticLink, bold, italic]
 #else
         self.defaultElements = [header, list, quote, link, automaticLink, bold, italic]
 #endif
@@ -168,8 +169,8 @@ open class CDMarkdownParser {
                                       value: paragraphStyle,
                                       range: range)
         var elements: [CDMarkdownElement] = escapingElements
-        elements.append(contentsOf: defaultElements)
         elements.append(contentsOf: customElements)
+        elements.append(contentsOf: defaultElements)
         elements.append(contentsOf: unescapingElements)
         elements.forEach { element in
             if automaticLinkDetectionEnabled || type(of: element) != CDMarkdownAutomaticLink.self {


### PR DESCRIPTION
### Issue Link :link:
https://github.com/chrisdhaan/CDMarkdownKit/issues/7

### Goals :soccer:
Add image scaling for larger images to fit.

### Implementation Details :construction:
Add an optional frame element, if set adjust attachment bounds to that frame's width.

### Testing Details :mag:
No tests were added.
