### PR TITLE
Swift 4 migration for macOS target

### DIFF
--- a/Source/CDFont.swift
+++ b/Source/CDFont.swift
@@ -34,5 +34,15 @@ import Foundation
 #elseif os(macOS)
     import Cocoa
     public typealias CDFont = NSFont
-    public typealias CDFontDescriptorSymbolicTraits = NSFontSymbolicTraits
+    #if swift(>=4.0)
+        public typealias CDFontDescriptorSymbolicTraits = NSFontDescriptor.SymbolicTraits
+
+        extension CDFontDescriptorSymbolicTraits {
+            init(_ rawValue: UInt32) {
+                self.init(rawValue: rawValue)
+            }
+        }
+    #else
+        public typealias CDFontDescriptorSymbolicTraits = NSFontSymbolicTraits
+    #endif
 #endif

--- a/Source/CDImage.swift
+++ b/Source/CDImage.swift
@@ -33,4 +33,12 @@ import Foundation
 #elseif os(macOS)
     import Cocoa
     public typealias CDImage = NSImage
+
+    #if swift(>=4.0)
+    extension NSImage {
+        convenience init?(named name: String) {
+            self.init(named: NSImage.Name(rawValue: name))
+        }
+    }
+    #endif
 #endif


### PR DESCRIPTION
### Issue Link :link:
#5 

### Goals :soccer:
Make the macOS target compatible with the Swift 4 compiler.

### Implementation Details :construction:
I've created two bridging extensions to keep the code backward compatible.

### Testing Details :mag:
No tests were added.
