### PR TITLE
Improved font size conversion in header element

### DIFF
--- a/Source/CDFont.swift
+++ b/Source/CDFont.swift
@@ -35,4 +35,15 @@ import Foundation
     import Cocoa
     public typealias CDFont = NSFont
     public typealias CDFontDescriptorSymbolicTraits = NSFontSymbolicTraits
+
+    extension NSFont {
+        func withSize(_ fontSize: CGFloat) -> NSFont {
+            #if swift(>=4.0)
+                let fontManager = NSFontManager.shared
+            #else
+                let fontManager = NSFontManager.shared()
+            #endif
+            return fontManager.convert(self, toSize: fontSize)
+        }
+    }
 #endif

--- a/Source/CDFont.swift
+++ b/Source/CDFont.swift
@@ -35,15 +35,4 @@ import Foundation
     import Cocoa
     public typealias CDFont = NSFont
     public typealias CDFontDescriptorSymbolicTraits = NSFontSymbolicTraits
-
-    extension NSFont {
-        func withSize(_ fontSize: CGFloat) -> NSFont {
-            #if swift(>=4.0)
-                let fontManager = NSFontManager.shared
-            #else
-                let fontManager = NSFontManager.shared()
-            #endif
-            return fontManager.convert(self, toSize: fontSize)
-        }
-    }
 #endif

--- a/Source/CDMarkdownHeader.swift
+++ b/Source/CDMarkdownHeader.swift
@@ -113,8 +113,7 @@ open class CDMarkdownHeader: CDMarkdownLevelElement {
         }
         if let font = font {
             let headerFontSize: CGFloat = font.pointSize + (CGFloat(fontMultiplier) * CGFloat(fontIncrease))
-            let headerFont = CDFont(name: font.fontName,
-                                    size: headerFontSize)
+            let headerFont = font.withSize(headerFontSize)
 #if swift(>=4.0)
             attributes[NSAttributedStringKey.font] = headerFont
 #else

--- a/Source/UIFont+CDMarkdownKit.swift
+++ b/Source/UIFont+CDMarkdownKit.swift
@@ -41,12 +41,24 @@ internal extension CDFont {
                       size: 0)!
     }
 
+    private var fontManager: NSFontManager {
+        #if swift(>=4.0)
+        return NSFontManager.shared
+        #else
+        return NSFontManager.shared()
+        #endif
+    }
+
     func bold() -> CDFont {
         return withTraits(NSFontBoldTrait)
     }
 
     func italic() -> CDFont {
         return withTraits(NSFontItalicTrait)
+    }
+
+    func withSize(_ fontSize: CGFloat) -> NSFont {
+        return fontManager.convert(self, toSize: fontSize)
     }
 }
 


### PR DESCRIPTION
### Issue Link :link:
I've noticed that UIKit changes the family of certain fonts dynamically based on the font size. Here is an example of this behavior:

```
let font = UIFont.systemFont(ofSize: 17)    // font-family: ".SFUIText"
let biggerFont = font.withSize(20)          // font-family: ".SFUIDisplay"
```
I've modified the header element to reflect these changes.

### Testing Details :mag:
No tests were added.
