### PR TITLE
Fixed issue with font trait conversion on macOS

### DIFF
--- a/Source/UIFont+CDMarkdownKit.swift
+++ b/Source/UIFont+CDMarkdownKit.swift
@@ -35,18 +35,20 @@
 
 internal extension CDFont {
 
-    private func withTraits(_ trait: Int) -> CDFont {
-        let descriptor = fontDescriptor.withSymbolicTraits(CDFontDescriptorSymbolicTraits(UInt32(trait)))
-        return CDFont(descriptor: descriptor,
-                      size: 0)!
+    private var fontManager: NSFontManager {
+        #if swift(>=4.0)
+        return NSFontManager.shared
+        #else
+        return NSFontManager.shared()
+        #endif
     }
 
     func bold() -> CDFont {
-        return withTraits(NSFontBoldTrait)
+        return fontManager.convert(self, toHaveTrait: .boldFontMask)
     }
 
     func italic() -> CDFont {
-        return withTraits(NSFontItalicTrait)
+        return fontManager.convert(self, toHaveTrait: .italicFontMask)
     }
 }
 
@@ -57,7 +59,7 @@ internal extension CDFont {
     private func withTraits(_ traits: CDFontDescriptorSymbolicTraits...) -> CDFont {
         let descriptor = fontDescriptor.withSymbolicTraits(CDFontDescriptorSymbolicTraits(traits))
         return CDFont(descriptor: descriptor!,
-                      size: 0)
+                      size: self.pointSize)
     }
 
     func bold() -> CDFont {


### PR DESCRIPTION
### Issue Link :link:
There is an issue on macOS with changing font traits via the descriptor. The new traits get applied but the original font family is not retained:

```
let font = NSFont.init(name: "HelveticaNeue", size: 17.0)  
// HelveticaNeue 17.00 pt.
let boldFont = NSFont(descriptor: (font!.fontDescriptor.withSymbolicTraits(NSFontDescriptor.SymbolicTraits(rawValue: UInt32(NSFontBoldTrait)))), size: 17.0) 
// AlBayan-Bold 17.00 pt.
```

### Implementation Details :construction:
A better (and more readable) approach is to use `NSFontManager` on macOS:

```
let font = NSFont.init(name: "HelveticaNeue", size: 17.0)
// HelveticaNeue 17.00 pt.
let boldFont = NSFontManager.shared.convert(font!, toHaveTrait: .boldFontMask)
// HelveticaNeue-Bold 17.00 pt.
```

### Testing Details :mag:
No tests were added.
