### PR TITLE
Made the framework compile on Xcode 11.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.2
 //
 //  Package.swift
 //  CDMarkdownKit
@@ -38,6 +39,5 @@ let package = Package(
         .target(
             name: "CDMarkdownKit",
             path: "Source")
-    ],
-    swiftLanguageVersions: [3, 4]
+    ]
 )

--- a/Source/CDMarkdownLabel.swift
+++ b/Source/CDMarkdownLabel.swift
@@ -319,9 +319,7 @@ open class CDMarkdownLabel: UILabel {
                 self.selectedURLRange = nil
             }
             avoidSuperCall = true
-        case .cancelled:
-            self.selectedURLRange = nil
-        case .stationary:
+        default:
             break
         }
 

--- a/Source/CDMarkdownParser.swift
+++ b/Source/CDMarkdownParser.swift
@@ -153,7 +153,7 @@ open class CDMarkdownParser {
     }
 
     open func removeCustomElement(_ element: CDMarkdownElement) {
-        guard let index = customElements.index(where: { someElement -> Bool in
+        guard let index = customElements.firstIndex(where: { someElement -> Bool in
             return element === someElement
         }) else {
             return


### PR DESCRIPTION
### Issue Link 
#21 

### Goals :soccer:
Updated a `switch` statement to handle additional `UITouch` cases and updated the `Package.swift` to use the 5.2 toolchain

