### PR TITLE
SPM issues fixed

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,5 @@
+// swift-tools-version:5.3
+
 //
 //  Package.swift
 //  CDMarkdownKit
@@ -47,5 +49,5 @@ let package = Package(
             path: "Source"
         )
     ],
-    swiftLanguageVersions: [.v5])
+    swiftLanguageVersions: [.v5]
 )

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
### Goals :soccer:
> Swift Package Manager hotfix for Xcode 12.0.1

### Implementation Details :construction:
> Explicit swift-tools-version declared
> CFBundleExecutable key removed from `Info.plist` to avoid App Store Connect error.