### PR TITLE
Add strikethrough support

### DIFF
--- a/CDMarkdownKit.xcodeproj/project.pbxproj
+++ b/CDMarkdownKit.xcodeproj/project.pbxproj
@@ -151,6 +151,10 @@
 		B2B366361F324DE90078B962 /* String+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B3661D1F324DE90078B962 /* String+CDMarkdownKit.swift */; };
 		B2B366371F324DE90078B962 /* CDColor+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B3661E1F324DE90078B962 /* CDColor+CDMarkdownKit.swift */; };
 		B2B366381F324DE90078B962 /* CDFont+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B3661F1F324DE90078B962 /* CDFont+CDMarkdownKit.swift */; };
+		E438794B28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = E438794A28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift */; };
+		E438794C28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = E438794A28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift */; };
+		E438794D28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = E438794A28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift */; };
+		E438794E28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = E438794A28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -205,6 +209,7 @@
 		B2D61BD320CF62F80091BFFF /* ISSUE_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = ISSUE_TEMPLATE.md; path = .github/ISSUE_TEMPLATE.md; sourceTree = "<group>"; };
 		B2D61BD420CF62F80091BFFF /* PULL_REQUEST_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = PULL_REQUEST_TEMPLATE.md; path = .github/PULL_REQUEST_TEMPLATE.md; sourceTree = "<group>"; };
 		B2FD53B520CFACA3004E97B5 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
+		E438794A28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDMarkdownStrikethrough.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -331,6 +336,7 @@
 				B2B366101F324DE90078B962 /* CDMarkdownList.swift */,
 				B2B366191F324DE90078B962 /* CDMarkdownQuote.swift */,
 				B2B3661B1F324DE90078B962 /* CDMarkdownSyntax.swift */,
+				E438794A28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift */,
 				B2B3663A1F324E040078B962 /* Escaping */,
 			);
 			name = Elements;
@@ -654,6 +660,7 @@
 				B2ACA0AA1FBF95A400EABEF6 /* CDMarkdownEscaping.swift in Sources */,
 				B2ACA0A21FBF95A400EABEF6 /* CDMarkdownHeader.swift in Sources */,
 				B267903B2868AC0E00DFAAA5 /* CDMarkdownKit.swift in Sources */,
+				E438794C28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift in Sources */,
 				B2ACA0A31FBF95A400EABEF6 /* CDMarkdownImage.swift in Sources */,
 				B2ACA0A41FBF95A400EABEF6 /* CDMarkdownItalic.swift in Sources */,
 				B29FE73D21AF01B6009A4BC1 /* Dictionary+CDMarkdownKit.swift in Sources */,
@@ -697,6 +704,7 @@
 				B2ACA0C31FBF960A00EABEF6 /* CDMarkdownEscaping.swift in Sources */,
 				B2ACA0BB1FBF960A00EABEF6 /* CDMarkdownHeader.swift in Sources */,
 				B267903C2868AC0E00DFAAA5 /* CDMarkdownKit.swift in Sources */,
+				E438794D28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift in Sources */,
 				B2ACA0BC1FBF960A00EABEF6 /* CDMarkdownImage.swift in Sources */,
 				B2ACA0BD1FBF960A00EABEF6 /* CDMarkdownItalic.swift in Sources */,
 				B29FE73E21AF01B6009A4BC1 /* Dictionary+CDMarkdownKit.swift in Sources */,
@@ -740,6 +748,7 @@
 				B2ACA0DC1FBF967800EABEF6 /* CDMarkdownEscaping.swift in Sources */,
 				B2ACA0D41FBF967800EABEF6 /* CDMarkdownHeader.swift in Sources */,
 				B267903D2868AC0E00DFAAA5 /* CDMarkdownKit.swift in Sources */,
+				E438794E28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift in Sources */,
 				B2ACA0D51FBF967800EABEF6 /* CDMarkdownImage.swift in Sources */,
 				B2ACA0D61FBF967800EABEF6 /* CDMarkdownItalic.swift in Sources */,
 				B29FE73F21AF01B6009A4BC1 /* Dictionary+CDMarkdownKit.swift in Sources */,
@@ -783,6 +792,7 @@
 				B2B3662E1F324DE90078B962 /* CDMarkdownEscaping.swift in Sources */,
 				B2B366271F324DE90078B962 /* CDMarkdownHeader.swift in Sources */,
 				B267903A2868AC0E00DFAAA5 /* CDMarkdownKit.swift in Sources */,
+				E438794B28C29DCD00BEE9FE /* CDMarkdownStrikethrough.swift in Sources */,
 				B2B366201F324DE90078B962 /* CDMarkdownImage.swift in Sources */,
 				B2B366281F324DE90078B962 /* CDMarkdownItalic.swift in Sources */,
 				B29FE73C21AF01B6009A4BC1 /* Dictionary+CDMarkdownKit.swift in Sources */,

--- a/Example/iOS Example.xcodeproj/project.pbxproj
+++ b/Example/iOS Example.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 				TargetAttributes = {
 					B2B365CA1F324A930078B962 = {
 						CreatedOnToolsVersion = 8.3.3;
+						DevelopmentTeam = C4H9246V88;
 						LastSwiftMigration = 0940;
 						ProvisioningStyle = Automatic;
 					};
@@ -430,9 +431,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = C4H9246V88;
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.christopherdehaan.iOS-Example";
+				PRODUCT_BUNDLE_IDENTIFIER = co.flickplay.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -441,9 +443,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = C4H9246V88;
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.christopherdehaan.iOS-Example";
+				PRODUCT_BUNDLE_IDENTIFIER = co.flickplay.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Example/iOS Example.xcodeproj/project.pbxproj
+++ b/Example/iOS Example.xcodeproj/project.pbxproj
@@ -195,7 +195,6 @@
 				TargetAttributes = {
 					B2B365CA1F324A930078B962 = {
 						CreatedOnToolsVersion = 8.3.3;
-						DevelopmentTeam = C4H9246V88;
 						LastSwiftMigration = 0940;
 						ProvisioningStyle = Automatic;
 					};
@@ -431,10 +430,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = C4H9246V88;
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = co.flickplay.example;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.christopherdehaan.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -443,10 +441,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = C4H9246V88;
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = co.flickplay.example;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.christopherdehaan.iOS-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Source/CDMarkdownBold.swift
+++ b/Source/CDMarkdownBold.swift
@@ -39,6 +39,8 @@ open class CDMarkdownBold: CDMarkdownCommonElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
 
     open var regex: String {
         return CDMarkdownBold.regex

--- a/Source/CDMarkdownCode.swift
+++ b/Source/CDMarkdownCode.swift
@@ -39,6 +39,8 @@ open class CDMarkdownCode: CDMarkdownCommonElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
 
     open var regex: String {
         return CDMarkdownCode.regex

--- a/Source/CDMarkdownHeader.swift
+++ b/Source/CDMarkdownHeader.swift
@@ -49,6 +49,8 @@ open class CDMarkdownHeader: CDMarkdownLevelElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
     open var fontIncrease: Int
 
     open var regex: String {

--- a/Source/CDMarkdownImage.swift
+++ b/Source/CDMarkdownImage.swift
@@ -41,6 +41,8 @@ open class CDMarkdownImage: CDMarkdownLinkElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
     open var size: CGSize?
 
     open var regex: String {

--- a/Source/CDMarkdownItalic.swift
+++ b/Source/CDMarkdownItalic.swift
@@ -39,6 +39,8 @@ open class CDMarkdownItalic: CDMarkdownCommonElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
 
     open var regex: String {
         return CDMarkdownItalic.regex

--- a/Source/CDMarkdownLink.swift
+++ b/Source/CDMarkdownLink.swift
@@ -39,6 +39,8 @@ open class CDMarkdownLink: CDMarkdownLinkElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
 
     open var regex: String {
         return CDMarkdownLink.regex
@@ -52,11 +54,15 @@ open class CDMarkdownLink: CDMarkdownLinkElement {
     public init(font: CDFont? = nil,
                 color: CDColor? = CDColor.blue,
                 backgroundColor: CDColor? = nil,
-                paragraphStyle: NSParagraphStyle? = nil) {
+                paragraphStyle: NSParagraphStyle? = nil,
+                underlineStyle: NSUnderlineStyle? = nil,
+                underlineColor: CDColor? = nil) {
         self.font = font
         self.color = color
         self.backgroundColor = backgroundColor
         self.paragraphStyle = paragraphStyle
+        self.underlineStyle = underlineStyle
+        self.underlineColor = underlineColor
     }
 
     open func formatText(_ attributedString: NSMutableAttributedString,

--- a/Source/CDMarkdownList.swift
+++ b/Source/CDMarkdownList.swift
@@ -40,6 +40,8 @@ open class CDMarkdownList: CDMarkdownLevelElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
     open var separator: String
     open var indicator: String
 

--- a/Source/CDMarkdownParser.swift
+++ b/Source/CDMarkdownParser.swift
@@ -50,6 +50,7 @@ open class CDMarkdownParser {
     public let italic: CDMarkdownItalic
     public let code: CDMarkdownCode
     public let syntax: CDMarkdownSyntax
+    public let strikethrough: CDMarkdownStrikethrough
 #if os(iOS) || os(macOS) || os(tvOS)
     public let image: CDMarkdownImage
 #endif
@@ -74,6 +75,8 @@ open class CDMarkdownParser {
                 fontColor: CDColor = CDColor.black,
                 backgroundColor: CDColor = CDColor.clear,
                 paragraphStyle: NSParagraphStyle? = nil,
+                strikethroughStyle: NSNumber? = nil,
+                strikethroughColor: CDColor = .black,
                 imageSize: CGSize? = nil,
                 automaticLinkDetectionEnabled: Bool = true,
                 customElements: [CDMarkdownElement] = []) {
@@ -128,6 +131,12 @@ open class CDMarkdownParser {
                                   color: fontColor,
                                   backgroundColor: backgroundColor,
                                   paragraphStyle: paragraphStyle)
+        strikethrough = CDMarkdownStrikethrough(font: font,
+                                                customLineStyle: strikethroughStyle,
+                                                strikethroughColor: strikethroughColor,
+                                                color: fontColor,
+                                                backgroundColor: backgroundColor,
+                                                paragraphStyle: paragraphStyle)
 #if os(iOS) || os(macOS) || os(tvOS)
         image = CDMarkdownImage(font: font,
                                 color: fontColor,
@@ -139,9 +148,9 @@ open class CDMarkdownParser {
         self.automaticLinkDetectionEnabled = automaticLinkDetectionEnabled
         self.escapingElements = [codeEscaping, escaping]
 #if os(iOS) || os(macOS) || os(tvOS)
-        self.defaultElements = [header, list, quote, link, automaticLink, image, bold, italic]
+        self.defaultElements = [header, list, quote, link, automaticLink, image, bold, italic, strikethrough]
 #else
-        self.defaultElements = [header, list, quote, link, automaticLink, bold, italic]
+        self.defaultElements = [header, list, quote, link, automaticLink, bold, italic, strikethrough]
 #endif
         self.unescapingElements = [code, syntax, unescaping]
         self.customElements = customElements

--- a/Source/CDMarkdownParser.swift
+++ b/Source/CDMarkdownParser.swift
@@ -75,10 +75,11 @@ open class CDMarkdownParser {
                 fontColor: CDColor = CDColor.black,
                 backgroundColor: CDColor = CDColor.clear,
                 paragraphStyle: NSParagraphStyle? = nil,
-                strikethroughStyle: NSNumber? = nil,
+                strikethroughStyle: NSUnderlineStyle? = nil,
                 strikethroughColor: CDColor = .black,
                 imageSize: CGSize? = nil,
                 automaticLinkDetectionEnabled: Bool = true,
+                linkUnderlineStyle: NSUnderlineStyle? = .single,
                 customElements: [CDMarkdownElement] = []) {
         self.font = font
         self.fontColor = fontColor
@@ -108,11 +109,13 @@ open class CDMarkdownParser {
         link = CDMarkdownLink(font: font,
                               color: fontColor,
                               backgroundColor: backgroundColor,
-                              paragraphStyle: paragraphStyle)
+                              paragraphStyle: paragraphStyle,
+                              underlineStyle: linkUnderlineStyle)
         automaticLink = CDMarkdownAutomaticLink(font: font,
                                                 color: fontColor,
                                                 backgroundColor: backgroundColor,
-                                                paragraphStyle: paragraphStyle)
+                                                paragraphStyle: paragraphStyle,
+                                                underlineStyle: linkUnderlineStyle)
         bold = CDMarkdownBold(font: font,
                               customBoldFont: boldFont,
                               color: fontColor,

--- a/Source/CDMarkdownQuote.swift
+++ b/Source/CDMarkdownQuote.swift
@@ -40,6 +40,8 @@ open class CDMarkdownQuote: CDMarkdownLevelElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
     open var separator: String
     open var indicator: String
 

--- a/Source/CDMarkdownStrikethrough.swift
+++ b/Source/CDMarkdownStrikethrough.swift
@@ -1,0 +1,74 @@
+//
+//  CDMarkdownStrikethrough.swift
+//  CDMarkdownKit
+//
+//  Created by Théo Arrouye on 9/1/22.
+//
+//  Copyright © 2022 Théo Arrouye
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#if os(iOS) || os(tvOS) || os(watchOS)
+import UIKit
+#elseif os(macOS)
+import Cocoa
+#endif
+
+open class CDMarkdownStrikethrough: CDMarkdownCommonElement {
+    
+    fileprivate static let regex = "()(~~)(.*?)(\\2)"
+    
+    open var font: CDFont?
+    open var color: CDColor?
+    open var backgroundColor: CDColor?
+    open var paragraphStyle: NSParagraphStyle?
+    open var strikethroughStyle: NSNumber
+    open var strikethroughColor: CDColor?
+    
+    open var regex: String {
+        return CDMarkdownStrikethrough.regex
+    }
+    
+    public init(font: CDFont? = nil,
+                customLineStyle: NSNumber? = nil,
+                strikethroughColor: CDColor? = nil,
+                color: CDColor? = nil,
+                backgroundColor: CDColor? = nil,
+                paragraphStyle: NSParagraphStyle? = nil) {
+        self.font = font
+        self.color = color
+        self.backgroundColor = backgroundColor
+        self.paragraphStyle = paragraphStyle
+        self.strikethroughStyle = customLineStyle ?? 1
+        self.strikethroughColor = strikethroughColor
+    }
+    
+    public func addAttributes(_ attributedString: NSMutableAttributedString, range: NSRange) {
+        var adjustedAttributes = attributes
+        
+        adjustedAttributes.addStrikethroughStyle(strikethroughStyle)
+        if let stColor = strikethroughColor {
+            adjustedAttributes.addStrikethroughColor(stColor)
+        }
+        
+        attributedString.addAttributes(adjustedAttributes, range: range)
+    }
+    
+}

--- a/Source/CDMarkdownStrikethrough.swift
+++ b/Source/CDMarkdownStrikethrough.swift
@@ -39,7 +39,9 @@ open class CDMarkdownStrikethrough: CDMarkdownCommonElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
-    open var strikethroughStyle: NSNumber
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
+    open var strikethroughStyle: NSUnderlineStyle
     open var strikethroughColor: CDColor?
     
     open var regex: String {
@@ -47,7 +49,7 @@ open class CDMarkdownStrikethrough: CDMarkdownCommonElement {
     }
     
     public init(font: CDFont? = nil,
-                customLineStyle: NSNumber? = nil,
+                customLineStyle: NSUnderlineStyle? = nil,
                 strikethroughColor: CDColor? = nil,
                 color: CDColor? = nil,
                 backgroundColor: CDColor? = nil,
@@ -56,7 +58,7 @@ open class CDMarkdownStrikethrough: CDMarkdownCommonElement {
         self.color = color
         self.backgroundColor = backgroundColor
         self.paragraphStyle = paragraphStyle
-        self.strikethroughStyle = customLineStyle ?? 1
+        self.strikethroughStyle = customLineStyle ?? .single
         self.strikethroughColor = strikethroughColor
     }
     

--- a/Source/CDMarkdownStyle.swift
+++ b/Source/CDMarkdownStyle.swift
@@ -38,6 +38,8 @@ public protocol CDMarkdownStyle {
     var color: CDColor? { get }
     var backgroundColor: CDColor? { get }
     var paragraphStyle: NSParagraphStyle? { get }
+    var underlineStyle: NSUnderlineStyle? { get }
+    var underlineColor: CDColor? { get }
     var attributes: [CDAttributedStringKey: AnyObject] { get }
 }
 
@@ -57,6 +59,12 @@ public extension CDMarkdownStyle {
         }
         if let paragraphStyle = paragraphStyle {
             attributes.addParagraphStyle(paragraphStyle)
+        }
+        if let underlineColor = underlineColor {
+            attributes.addUnderlineColor(underlineColor)
+        }
+        if let underlineStyle = underlineStyle {
+          attributes.addUnderlineStyle(underlineStyle)
         }
 
         return attributes

--- a/Source/CDMarkdownSyntax.swift
+++ b/Source/CDMarkdownSyntax.swift
@@ -39,6 +39,8 @@ open class CDMarkdownSyntax: CDMarkdownCommonElement {
     open var color: CDColor?
     open var backgroundColor: CDColor?
     open var paragraphStyle: NSParagraphStyle?
+    open var underlineStyle: NSUnderlineStyle?
+    open var underlineColor: CDColor?
 
     open var regex: String {
         return CDMarkdownSyntax.regex

--- a/Source/Dictionary+CDMarkdownKit.swift
+++ b/Source/Dictionary+CDMarkdownKit.swift
@@ -48,4 +48,21 @@ internal extension Dictionary where Key == CDAttributedStringKey {
     mutating func addParagraphStyle(_ paragraphStyle: Value) {
         self[NSAttributedString.Key.paragraphStyle] = paragraphStyle
     }
+    
+    mutating func addStrikethroughStyle(_ strikethroughStyle: Value) {
+        self[NSAttributedString.Key.strikethroughStyle] = strikethroughStyle
+    }
+    
+    mutating func addStrikethroughColor(_ strikethroughColor: Value) {
+        self[NSAttributedString.Key.strikethroughColor] = strikethroughColor
+    }
+    
+    mutating func addUnderlineStyle(_ underlineStyle: Value) {
+        self[NSAttributedString.Key.underlineStyle] = underlineStyle
+    }
+    
+    mutating func addUnderlineColor(_ underlineColor: Value) {
+        self[NSAttributedString.Key.underlineColor] = underlineColor
+    }
 }
+

--- a/Source/Dictionary+CDMarkdownKit.swift
+++ b/Source/Dictionary+CDMarkdownKit.swift
@@ -49,16 +49,16 @@ internal extension Dictionary where Key == CDAttributedStringKey {
         self[NSAttributedString.Key.paragraphStyle] = paragraphStyle
     }
     
-    mutating func addStrikethroughStyle(_ strikethroughStyle: Value) {
-        self[NSAttributedString.Key.strikethroughStyle] = strikethroughStyle
+    mutating func addStrikethroughStyle(_ strikethroughStyle: NSUnderlineStyle) {
+        self[NSAttributedString.Key.strikethroughStyle] = strikethroughStyle.rawValue as? Value
     }
     
     mutating func addStrikethroughColor(_ strikethroughColor: Value) {
         self[NSAttributedString.Key.strikethroughColor] = strikethroughColor
     }
     
-    mutating func addUnderlineStyle(_ underlineStyle: Value) {
-        self[NSAttributedString.Key.underlineStyle] = underlineStyle
+    mutating func addUnderlineStyle(_ underlineStyle: NSUnderlineStyle) {
+      self[NSAttributedString.Key.underlineStyle] = underlineStyle.rawValue as? Value
     }
     
     mutating func addUnderlineColor(_ underlineColor: Value) {


### PR DESCRIPTION

### Goals :soccer:
<!-- List the high-level objectives of this pull request. -->
<!-- Include any relevant context. -->
- Add `strikethrough` element that matches for markdown strikethrough (`~~example~~` ~~example~~)
- Add underline style/color styling options to all elements

### Implementation Details :construction:
<!-- Explain the reasoning behind any architectural changes. -->
<!-- Highlight any new functionality. -->
- Try to match the existing architecture as closely as possible
- Use the underline styling option to further differentiate links in default parser
    - This change can be undone and the underline can be left simply as option if you prefer to leave it out of the default parser for this library. 

### Testing Details :mag:
<!-- Describe what tests you've added for your changes. -->
- No changes