### PR TITLE
fix: add Async Image

### DIFF
--- a/CDMarkdownKit.xcodeproj/project.pbxproj
+++ b/CDMarkdownKit.xcodeproj/project.pbxproj
@@ -11,6 +11,14 @@
 		5F0AD09621063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
 		5F0AD09721063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
 		5F0AD09821063D36007B718F /* CDImage+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */; };
+		96E4225D2A45F5BA00B2EA17 /* AsyncAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E4225C2A45F5BA00B2EA17 /* AsyncAttachment.swift */; };
+		96E4225E2A45F5BA00B2EA17 /* AsyncAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E4225C2A45F5BA00B2EA17 /* AsyncAttachment.swift */; };
+		96E4225F2A45F5BA00B2EA17 /* AsyncAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E4225C2A45F5BA00B2EA17 /* AsyncAttachment.swift */; };
+		96E422602A45F5BA00B2EA17 /* AsyncAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E4225C2A45F5BA00B2EA17 /* AsyncAttachment.swift */; };
+		96E422622A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E422612A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift */; };
+		96E422632A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E422612A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift */; };
+		96E422642A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E422612A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift */; };
+		96E422652A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E422612A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift */; };
 		B205C6661FC129EB00E74CBA /* CDColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B205C6651FC129EB00E74CBA /* CDColor.swift */; };
 		B205C6671FC129EB00E74CBA /* CDColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B205C6651FC129EB00E74CBA /* CDColor.swift */; };
 		B205C6681FC129EB00E74CBA /* CDColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B205C6651FC129EB00E74CBA /* CDColor.swift */; };
@@ -159,6 +167,8 @@
 
 /* Begin PBXFileReference section */
 		5F0AD09421063D36007B718F /* CDImage+CDMarkdownKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CDImage+CDMarkdownKit.swift"; sourceTree = "<group>"; };
+		96E4225C2A45F5BA00B2EA17 /* AsyncAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncAttachment.swift; sourceTree = "<group>"; };
+		96E422612A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSLayoutManager+CDMarkdownKit.swift"; sourceTree = "<group>"; };
 		B205C6651FC129EB00E74CBA /* CDColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDColor.swift; sourceTree = "<group>"; };
 		B205C66A1FC129FC00E74CBA /* CDFont.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDFont.swift; sourceTree = "<group>"; };
 		B205C66F1FC135DF00E74CBA /* CDImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDImage.swift; sourceTree = "<group>"; };
@@ -364,6 +374,7 @@
 				B22C0E8521B195C4006CE401 /* NSTextCheckingResult+CDMarkdownKit.swift */,
 				B22C0E8D21B1AAD5006CE401 /* NSTextStorage+CDMarkdownKit.swift */,
 				B2B3661D1F324DE90078B962 /* String+CDMarkdownKit.swift */,
+				96E422612A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -383,6 +394,7 @@
 		B2B3663D1F324E940078B962 /* UI */ = {
 			isa = PBXGroup;
 			children = (
+				96E4225C2A45F5BA00B2EA17 /* AsyncAttachment.swift */,
 				B2B3660A1F324DE90078B962 /* CDMarkdownLabel.swift */,
 				B2B366161F324DE90078B962 /* CDMarkdownLayoutManager.swift */,
 				B2B366111F324DE90078B962 /* CDMarkdownTextView.swift */,
@@ -635,12 +647,14 @@
 				B29FE73D21AF01B6009A4BC1 /* Dictionary+CDMarkdownKit.swift in Sources */,
 				B2ACA0B41FBF95A400EABEF6 /* CDMarkdownLabel.swift in Sources */,
 				B2ACA0B51FBF95A400EABEF6 /* CDMarkdownLayoutManager.swift in Sources */,
+				96E4225E2A45F5BA00B2EA17 /* AsyncAttachment.swift in Sources */,
 				B2ACA0B11FBF95A400EABEF6 /* CDMarkdownLevelElement.swift in Sources */,
 				B2ACA0A51FBF95A400EABEF6 /* CDMarkdownLink.swift in Sources */,
 				B2ACA0B21FBF95A400EABEF6 /* CDMarkdownLinkElement.swift in Sources */,
 				B255AD8720D8000A00E8044D /* CDAttributedStringKey.swift in Sources */,
 				B2ACA0A61FBF95A400EABEF6 /* CDMarkdownList.swift in Sources */,
 				B22C0E8F21B1AAD5006CE401 /* NSTextStorage+CDMarkdownKit.swift in Sources */,
+				96E422632A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift in Sources */,
 				B22C0E9421B1AD16006CE401 /* NSAttributedString+CDMarkdownKit.swift in Sources */,
 				B22C0E8721B195C4006CE401 /* NSTextCheckingResult+CDMarkdownKit.swift in Sources */,
 				B2ACA09E1FBF95A400EABEF6 /* CDMarkdownParser.swift in Sources */,
@@ -679,12 +693,14 @@
 				B29FE73E21AF01B6009A4BC1 /* Dictionary+CDMarkdownKit.swift in Sources */,
 				B2ACA0CD1FBF960A00EABEF6 /* CDMarkdownLabel.swift in Sources */,
 				B2ACA0CE1FBF960A00EABEF6 /* CDMarkdownLayoutManager.swift in Sources */,
+				96E4225F2A45F5BA00B2EA17 /* AsyncAttachment.swift in Sources */,
 				B2ACA0CA1FBF960A00EABEF6 /* CDMarkdownLevelElement.swift in Sources */,
 				B2ACA0BE1FBF960A00EABEF6 /* CDMarkdownLink.swift in Sources */,
 				B2ACA0CB1FBF960A00EABEF6 /* CDMarkdownLinkElement.swift in Sources */,
 				B255AD8820D8000A00E8044D /* CDAttributedStringKey.swift in Sources */,
 				B2ACA0BF1FBF960A00EABEF6 /* CDMarkdownList.swift in Sources */,
 				B22C0E9021B1AAD5006CE401 /* NSTextStorage+CDMarkdownKit.swift in Sources */,
+				96E422642A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift in Sources */,
 				B22C0E9521B1AD16006CE401 /* NSAttributedString+CDMarkdownKit.swift in Sources */,
 				B22C0E8821B195C4006CE401 /* NSTextCheckingResult+CDMarkdownKit.swift in Sources */,
 				B2ACA0C01FBF960A00EABEF6 /* CDMarkdownQuote.swift in Sources */,
@@ -723,12 +739,14 @@
 				B29FE73F21AF01B6009A4BC1 /* Dictionary+CDMarkdownKit.swift in Sources */,
 				B2ACA0E61FBF967800EABEF6 /* CDMarkdownLabel.swift in Sources */,
 				B2ACA0E71FBF967800EABEF6 /* CDMarkdownLayoutManager.swift in Sources */,
+				96E422602A45F5BA00B2EA17 /* AsyncAttachment.swift in Sources */,
 				B2ACA0E31FBF967800EABEF6 /* CDMarkdownLevelElement.swift in Sources */,
 				B2ACA0D71FBF967800EABEF6 /* CDMarkdownLink.swift in Sources */,
 				B2ACA0E41FBF967800EABEF6 /* CDMarkdownLinkElement.swift in Sources */,
 				B255AD8920D8000A00E8044D /* CDAttributedStringKey.swift in Sources */,
 				B2ACA0D81FBF967800EABEF6 /* CDMarkdownList.swift in Sources */,
 				B22C0E9121B1AAD5006CE401 /* NSTextStorage+CDMarkdownKit.swift in Sources */,
+				96E422652A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift in Sources */,
 				B22C0E9621B1AD16006CE401 /* NSAttributedString+CDMarkdownKit.swift in Sources */,
 				B22C0E8921B195C4006CE401 /* NSTextCheckingResult+CDMarkdownKit.swift in Sources */,
 				B2ACA0D01FBF967800EABEF6 /* CDMarkdownParser.swift in Sources */,
@@ -767,12 +785,14 @@
 				B29FE73C21AF01B6009A4BC1 /* Dictionary+CDMarkdownKit.swift in Sources */,
 				B2B366231F324DE90078B962 /* CDMarkdownLabel.swift in Sources */,
 				B2B3662F1F324DE90078B962 /* CDMarkdownLayoutManager.swift in Sources */,
+				96E4225D2A45F5BA00B2EA17 /* AsyncAttachment.swift in Sources */,
 				B2B366301F324DE90078B962 /* CDMarkdownLevelElement.swift in Sources */,
 				B2B366211F324DE90078B962 /* CDMarkdownLink.swift in Sources */,
 				B2B366311F324DE90078B962 /* CDMarkdownLinkElement.swift in Sources */,
 				B255AD8620D8000A00E8044D /* CDAttributedStringKey.swift in Sources */,
 				B2B366291F324DE90078B962 /* CDMarkdownList.swift in Sources */,
 				B22C0E8E21B1AAD5006CE401 /* NSTextStorage+CDMarkdownKit.swift in Sources */,
+				96E422622A45F5DA00B2EA17 /* NSLayoutManager+CDMarkdownKit.swift in Sources */,
 				B22C0E9321B1AD16006CE401 /* NSAttributedString+CDMarkdownKit.swift in Sources */,
 				B22C0E8621B195C4006CE401 /* NSTextCheckingResult+CDMarkdownKit.swift in Sources */,
 				B2B366321F324DE90078B962 /* CDMarkdownQuote.swift in Sources */,

--- a/Source/AsyncAttachment.swift
+++ b/Source/AsyncAttachment.swift
@@ -1,0 +1,170 @@
+//
+//  AsyncTextAttachment.swift
+//  CDMarkdownKit
+//
+//  Created by 박형환 on 2023/06/24.
+//  Copyright © 2023 Christopher de Haan. All rights reserved.
+//
+#if os(iOS)
+import UIKit
+
+
+@objc public protocol AsyncTextAttachmentDelegate{
+   /// Called when the image has been loaded
+   func textAttachmentDidLoadImage(textAttachment: AsyncTextAttachment,
+                                   displaySizeChanged: Bool)
+}
+
+extension CDMarkdownImage: AsyncTextAttachmentDelegate{
+    public func textAttachmentDidLoadImage(textAttachment: AsyncTextAttachment, displaySizeChanged: Bool) {
+        print("textAttachment: \(textAttachment)")
+        print("displaySizeChanged: \(displaySizeChanged)")
+    }
+}
+
+/// An image text attachment that gets loaded from a remote URL
+public class AsyncTextAttachment: NSTextAttachment{
+    /// Remote URL for the image
+    public var imageURL: URL?
+    
+    /// To specify an absolute display size.
+    public var displaySize: CGSize?
+    
+    /// if determining the display size automatically this can be used to specify a
+    /// maximum width. If it is not set then the text container's width will be used
+    public var maximumDisplayWidth: CGFloat?
+    
+    /// A delegate to be informed of the finished download
+    public weak var delegate: AsyncTextAttachmentDelegate?
+    
+    /// Remember the text container from delegate message
+    weak var textContainer: NSTextContainer?
+    
+    /// The download task to keep track of whether we are already downloading the image
+    private var downloadTask: URLSessionTask!
+    
+    /// The size of the downloaded image. Used if we need to determine display size
+    private var originalImageSize: CGSize?
+    
+    /// Designated initializer
+    public init(imageURL: URL? = nil, delegate: AsyncTextAttachmentDelegate? = nil)
+    {
+        self.imageURL = imageURL
+        self.delegate = delegate
+        
+        super.init(data: nil, ofType: nil)
+    }
+    
+    required public init?(coder aDecoder: NSCoder)
+    {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override public var image: CDImage?
+    {
+        didSet
+        {
+            originalImageSize = image?.size
+        }
+    }
+    
+    public override func attachmentBounds(for textContainer: NSTextContainer?,
+                          proposedLineFragment lineFrag: CGRect,
+                          glyphPosition position: CGPoint,
+                          characterIndex charIndex: Int) -> CGRect
+    {
+        if let displaySize = displaySize
+        {
+            return CGRect(origin: CGPoint.zero, size: displaySize)
+        }
+        
+        if let imageSize = originalImageSize
+        {
+            let maxWidth = maximumDisplayWidth ?? lineFrag.size.width
+            let factor = maxWidth / imageSize.width
+            
+            return CGRect(origin: CGPoint.zero,
+                          size:CGSize(width: Int(imageSize.width * factor),
+                                      height: Int(imageSize.height * factor)))
+        }
+        return CGRect.zero
+    }
+
+    
+    public override func image(forBounds imageBounds: CGRect,
+                               textContainer: NSTextContainer?,
+                               characterIndex charIndex: Int) -> CDImage?
+    {
+        if let image = image
+        {
+            return image
+        }
+        guard let contents = contents, let image = CDImage(data: contents) else
+        {
+            // remember reference so that we can update it later
+            self.textContainer = textContainer
+            startAsyncImageDownload()
+            return nil
+        }
+        return image
+    }
+    
+    
+    private func startAsyncImageDownload()
+    {
+       guard let imageURL = imageURL,contents == nil && downloadTask == nil else
+       {
+          return
+       }
+        
+        downloadTask = URLSession.shared.dataTask(with: imageURL) {
+          (data, response, error) in
+            
+          defer
+          {
+             // done with the task
+             self.downloadTask = nil
+          }
+                
+          guard let data = data , error == nil else {
+//             print(error?.localizedDescription)
+             return
+          }
+                
+          var displaySizeChanged = false
+            self.contents = data
+                
+          if let image = CDImage(data: data)
+          {
+             let imageSize = image.size
+                    
+             if self.displaySize == nil
+             {
+                displaySizeChanged = true
+             }
+                    
+             self.originalImageSize = imageSize
+          }
+                
+           DispatchQueue.main.async { [weak self] in
+               guard let self else {return}
+               // tell layout manager so that it should refresh
+               if displaySizeChanged
+               {
+                  self.textContainer?.layoutManager?.setNeedsLayout(forAttachment: self)
+               }
+               else
+               {
+                  self.textContainer?.layoutManager?.setNeedsDisplay(forAttachment: self)
+               }
+                      
+               // notify the optional delegate
+               self.delegate?.textAttachmentDidLoadImage(textAttachment: self,
+                                                         displaySizeChanged: displaySizeChanged)
+           }
+       }
+            
+       downloadTask.resume()
+    }
+}
+#endif

--- a/Source/CDMarkdownImage.swift
+++ b/Source/CDMarkdownImage.swift
@@ -99,7 +99,11 @@ open class CDMarkdownImage: CDMarkdownLinkElement {
         attributedString.deleteCharacters(in: NSRange(location: match.range.location,
                                                       length: linkRange.length + 2))
 
-        // load image
+        // load image async and apply when download finish
+        #if os(iOS)
+        let textAttachment = AsyncTextAttachment(imageURL: URL(string: linkURLString),delegate: self)
+        textAttachment.maximumDisplayWidth = size?.width
+        #else
         let textAttachment = NSTextAttachment()
         if let url = URL(string: linkURLString) {
             let data = try? Data(contentsOf: url)
@@ -116,6 +120,7 @@ open class CDMarkdownImage: CDMarkdownLinkElement {
                                          forImage: image)
             }
         }
+        #endif
 
         // replace text with image
         let textAttachmentAttributedString = NSAttributedString(attachment: textAttachment)

--- a/Source/NSLayoutManager+CDMarkdownKit.swift
+++ b/Source/NSLayoutManager+CDMarkdownKit.swift
@@ -1,0 +1,79 @@
+//
+//  NSLayoutManager+CDMarkdownKit.swift
+//  CDMarkdownKit
+//
+//  Created by 박형환 on 2023/06/24.
+//  Copyright © 2023 Christopher de Haan. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS) || os(watchOS)
+import UIKit
+#elseif os(macOS)
+import Cocoa
+#endif
+
+
+
+extension NSLayoutManager{
+    /// Determine the character ranges for an attachment
+    private func rangesForAttachment(attachment: NSTextAttachment) -> [NSRange]?{
+        guard let attributedString = self.textStorage else
+        {
+            return nil
+        }
+        
+        // find character range for this attachment
+        let range = NSRange(location: 0, length: attributedString.length)
+        
+        var refreshRanges = [NSRange]()
+        
+        attributedString.enumerateAttribute(NSAttributedString.Key.attachment,
+                                            in: range, options: []) {
+            (value, effectiveRange, nil) in
+            
+            guard let foundAttachment = value as? NSTextAttachment, foundAttachment == attachment else
+            {
+                return
+            }
+            
+            // add this range to the refresh ranges
+            refreshRanges.append(effectiveRange)
+        }
+        
+        if refreshRanges.count == 0
+        {
+            return nil
+        }
+        
+        return refreshRanges
+    }
+    
+    /// Trigger a re-display for an attachment
+    public func setNeedsDisplay(forAttachment attachment: NSTextAttachment){
+        guard let ranges = rangesForAttachment(attachment: attachment) else
+        {
+            return
+        }
+        
+        // invalidate the display for the corresponding ranges
+        ranges.reversed().forEach { (range) in
+            self.invalidateDisplay(forGlyphRange: range)
+        }
+    }
+    /// Trigger a relayout for an attachment
+    public func setNeedsLayout(forAttachment attachment: NSTextAttachment){
+        guard let ranges = rangesForAttachment(attachment: attachment) else
+        {
+            return
+        }
+        
+        
+        // invalidate the display for the corresponding ranges
+        ranges.reversed().forEach { (range) in
+            self.invalidateLayout(forCharacterRange: range, actualCharacterRange: nil)
+            
+            // also need to trigger re-display or already visible images might not get updated
+            self.invalidateDisplay(forGlyphRange: range)
+        }
+    }
+}


### PR DESCRIPTION
### Issue 
An error occurred. in  CDMarkdownImage class -> "let data = try? Data(contentsOf: url)" 
Synchronous URL loading of https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Gatto_europeo4.jpg/250px-Gatto_europeo4.jpg should not occur on this application's main thread as it may lead to UI unresponsiveness. Please switch to an asynchronous networking API such as URLSession. 

### Goals :soccer:
My goal is to asynchronously fetch an image and reflect it in the view to resolve this error.

### Implementation Details :construction:
I added the AsyncTextAttachment class to fetch the image asynchronously, and I wrote an extension for NSLayoutManager to track the size of the attachment. When the startAsyncImageDownload() function is executed, a function is called to apply the layout. And when the task is completed, it calls the delegate to notify that it has finished.

### Testing Details :mag:
I added "#if os(iOS)" because I tested it only on iOS.
It works well on iOS.

