### PR TITLE
Wire up CI to run the iOS/tvOS/visionOS test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,42 @@ jobs:
           set -o pipefail
           env NSUnbufferedIO=YES xcodebuild -project "CDMarkdownKit.xcodeproj" -scheme "CDMarkdownKit iOS" -destination "${{ matrix.destination }}" -configuration Release clean build 2>&1 | xcbeautify --renderer github-actions
 
+  UITests:
+    name: Run Tests (${{ matrix.name }})
+    runs-on: macos-26
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - destination: "OS=26.5,name=iPhone 17 Pro"
+            name: "iOS 26"
+          - destination: "OS=26.5,name=Apple TV 4K (3rd generation) (at 1080p)"
+            name: "tvOS 26"
+          - destination: "OS=26.5,name=Apple Vision Pro"
+            name: "visionOS 26"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+      - name: Install xcbeautify
+        run: brew install xcbeautify
+      - name: List available simulators
+        run: xcrun simctl list
+      # CDMarkdownKit.xcodeproj's 5 native schemes have no Testables wired (see #61), and its
+      # mere presence in this directory shadows the SPM package's own auto-generated
+      # "CDMarkdownKit-Package" scheme, which DOES run tests. Staging the package files alone
+      # in a directory without the .xcodeproj lets xcodebuild fall back to that scheme instead.
+      - name: Stage bare SPM package
+        run: |
+          mkdir -p "${{ runner.temp }}/cdmk-package"
+          cp -R Source Tests Package.swift Package.resolved "${{ runner.temp }}/cdmk-package/"
+      - name: ${{ matrix.name }}
+        run: |
+          set -o pipefail
+          cd "${{ runner.temp }}/cdmk-package"
+          env NSUnbufferedIO=YES xcodebuild test -scheme CDMarkdownKit-Package -destination "${{ matrix.destination }}" 2>&1 | xcbeautify --renderer github-actions
+
   macOS:
     name: Test ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Unreleased](#unreleased)
 - [4.0.3](#403)
 - [4.0.2](#402)
 - [4.0.1](#401)
@@ -24,6 +25,18 @@ All notable changes to this project will be documented in this file.
 - [1.2.0](#120)
 - [1.1.0](#110)
 - [1.0.0](#100)
+
+---
+
+## [Unreleased]
+
+### Added
+
+- CI now runs the full test suite against real iOS, tvOS, and visionOS simulators, in addition to the existing build-only checks for those platforms.
+
+### Fixed
+
+- Fixed several test files failing to compile for visionOS, due to a platform check that predated visionOS support and was never updated to include it.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ Defined in `.github/workflows/ci.yml`. Triggered on push to `master` and on pull
 | tvOS | matrix: Xcode 26.2–26.5 (macos-26) / Xcode 16.4 (macos-15) | macos-26 / macos-15 | xcodebuild |
 | watchOS | matrix: Xcode 26.2–26.5 (macos-26) / Xcode 16.4 (macos-15) | macos-26 / macos-15 | xcodebuild |
 | visionOS | matrix: Xcode 26.2–26.5 (macos-26) | macos-26 | xcodebuild |
+| UITests | single, per-platform (iOS/tvOS/visionOS) | macos-26, Xcode 26.5 | xcodebuild test |
 | Catalyst | single | macos-15, Xcode 16.4 | xcodebuild |
 | CocoaPods | single | macos-15, Xcode 16.4 | pod lib lint |
 | SPM | single | macos-15, Xcode 16.4 | swift test |
@@ -251,6 +252,8 @@ Defined in `.github/workflows/ci.yml`. Triggered on push to `master` and on pull
 | CodeQL | single | macos-15, Xcode 16.4 | codeql-action |
 
 iOS/tvOS/watchOS jobs run 5 matrix entries each (4 Xcode 26.x on macos-26, 1 Xcode 16.4 on macos-15), both Debug and Release builds. visionOS runs 4 entries (macos-26 only), both Debug and Release. macOS/Catalyst/CocoaPods/SPM/SwiftLint/SwiftFormat/Documentation/CodeQL jobs run singles. All jobs use `actions/checkout@v4`, `xcbeautify --renderer github-actions`, and `set -o pipefail`.
+
+`UITests` actually executes the iOS/tvOS/visionOS-gated test suite (`Tests/CDMarkdownKitTests/UI/` and friends) against a real simulator, one platform per matrix entry — see "Running iOS/tvOS/visionOS-gated tests locally" below for why it stages a bare copy of `Source/`/`Tests/`/`Package.swift` rather than using `CDMarkdownKit.xcodeproj` directly. watchOS has no UI-gated components (see the UI Components table above) so it's excluded from this job's matrix.
 
 ### Debugging CI Destination Failures
 
@@ -298,7 +301,7 @@ xcodebuild -project CDMarkdownKit.xcodeproj \
            clean build
 ```
 
-### Running iOS/tvOS/visionOS-gated tests locally (workaround for missing CI test wiring)
+### Running iOS/tvOS/visionOS-gated tests locally
 
 `swift test` only runs on the macOS host, where every file under `#if os(iOS) || os(tvOS) || os(visionOS)` compiles to nothing — it cannot execute or even compile-check UIKit-gated tests (e.g. everything in `Tests/CDMarkdownKitTests/UI/`). `xcodebuild -project CDMarkdownKit.xcodeproj` doesn't help either: none of its 5 schemes have `CDMarkdownKitTests` wired into their Testables, and `xcodebuild -list` run from the repo root never shows an SPM package scheme, because the `.xcodeproj`'s presence shadows it.
 
@@ -318,7 +321,7 @@ xcodebuild test -scheme CDMarkdownKit-Package \
 rm -rf "$SCRATCH"
 ```
 
-This actually compiles and runs the full suite (Swift Testing + XCTest) against a real simulator — not just a typecheck. It's how a handful of real production bugs (`configureTK2()` never configuring TextKit 2, `urlRangeTK1(at:)` missing a coordinate-space offset, a `CDMarkdownTextView` initializer crash) were actually caught: none of them were visible to `swift build`, `swift test`, or `xcodebuild clean build`, only to a real test run. This is a local workaround, not a CI fix — wiring this into `.github/workflows/ci.yml` and the checked-in `.xcodeproj` schemes properly is still an open item.
+This actually compiles and runs the full suite (Swift Testing + XCTest) against a real simulator — not just a typecheck. It's how a handful of real production bugs (`configureTK2()` never configuring TextKit 2, `urlRangeTK1(at:)` missing a coordinate-space offset, a `CDMarkdownTextView` initializer crash) were actually caught: none of them were visible to `swift build`, `swift test`, or `xcodebuild clean build`, only to a real test run. This is now automated as CI's `UITests` job (see the CI table above). Wiring `CDMarkdownKitTests` into the checked-in `.xcodeproj` schemes' native Testables directly (rather than working around the `.xcodeproj`'s presence) remains an open item — it needs the Xcode GUI, since hand-editing `project.pbxproj`'s Swift package product references for a test-only target isn't reliably reproducible via script (confirmed: `xcodebuild` reports "Missing package product" even when the object graph looks correct).
 
 ---
 

--- a/Tests/CDMarkdownKitTests/Elements/CDMarkdownHorizontalRuleTests.swift
+++ b/Tests/CDMarkdownKitTests/Elements/CDMarkdownHorizontalRuleTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     import UIKit
 #elseif os(macOS)
     import Cocoa

--- a/Tests/CDMarkdownKitTests/Elements/CDMarkdownListTests.swift
+++ b/Tests/CDMarkdownKitTests/Elements/CDMarkdownListTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     import UIKit
 #elseif os(macOS)
     import Cocoa

--- a/Tests/CDMarkdownKitTests/Elements/CDMarkdownOrderedListTests.swift
+++ b/Tests/CDMarkdownKitTests/Elements/CDMarkdownOrderedListTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     import UIKit
 #elseif os(macOS)
     import Cocoa

--- a/Tests/CDMarkdownKitTests/Elements/CDMarkdownQuoteTests.swift
+++ b/Tests/CDMarkdownKitTests/Elements/CDMarkdownQuoteTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     import UIKit
 #elseif os(macOS)
     import Cocoa

--- a/Tests/CDMarkdownKitTests/Elements/CDMarkdownStrikethroughTests.swift
+++ b/Tests/CDMarkdownKitTests/Elements/CDMarkdownStrikethroughTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     import UIKit
 #elseif os(macOS)
     import Cocoa

--- a/Tests/CDMarkdownKitTests/Elements/CDMarkdownTableTests.swift
+++ b/Tests/CDMarkdownKitTests/Elements/CDMarkdownTableTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     import UIKit
 #elseif os(macOS)
     import Cocoa

--- a/Tests/CDMarkdownKitTests/Elements/CDMarkdownTaskListTests.swift
+++ b/Tests/CDMarkdownKitTests/Elements/CDMarkdownTaskListTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     import UIKit
 #elseif os(macOS)
     import Cocoa

--- a/Tests/CDMarkdownKitTests/Parser/CDMarkdownParserDisabledElementTests.swift
+++ b/Tests/CDMarkdownKitTests/Parser/CDMarkdownParserDisabledElementTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     import UIKit
 #elseif os(macOS)
     import Cocoa

--- a/Tests/CDMarkdownKitTests/Parser/CDMarkdownParserInsertionTests.swift
+++ b/Tests/CDMarkdownKitTests/Parser/CDMarkdownParserInsertionTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     import UIKit
 #elseif os(macOS)
     import Cocoa


### PR DESCRIPTION
## Summary
- `CDMarkdownKit.xcodeproj`'s 5 native schemes have no Testables wired, and its presence shadows the SPM package's own auto-generated scheme, so no CI job ever actually compiled or ran the iOS/tvOS/visionOS-gated test suite (only build-checked it, or ran the macOS-only subset via `swift test`).
- Attempted to wire `CDMarkdownKitTests` in as a native package product dependency via the `xcodeproj` gem (safer than hand-editing `project.pbxproj`, per the issue's own concern) — dead end: `xcodebuild` reports `Missing package product 'CDMarkdownKitTests'` even with a correctly-formed object graph, since SPM test targets aren't real "products." Reverted that approach entirely; the `.xcodeproj` is untouched by this PR.
- Instead, automated the already-documented local workaround: added a `UITests` CI job that stages `Source/`, `Tests/`, `Package.swift` into a directory without the `.xcodeproj`, so `xcodebuild` falls back to the package's own `CDMarkdownKit-Package` scheme, which has working Testables. Runs against iOS, tvOS, and visionOS (watchOS has no UI-gated components, so it's excluded).
- Fixed 9 test files where `#if os(iOS) || os(tvOS) || os(watchOS)` was missing `os(visionOS)` — a pre-existing oversight from visionOS's introduction that only surfaced once these files actually got compiled for that platform. Two of them reference `NSParagraphStyle` (a UIKit type on iOS/tvOS/visionOS, a Foundation type on macOS), so the missing branch broke the visionOS build outright.
- Updated CLAUDE.md's CI job table and the "local workaround" section, which previously said CI wiring was "still an open item."

Closes #61.

## Test plan
- [x] `xcodebuild test -scheme CDMarkdownKit-Package` against iPhone 17 Pro (iOS 26): 230/230 passed
- [x] Same, Apple TV 4K (tvOS 26): 230/230 passed
- [x] Same, Apple Vision Pro (visionOS 26): 224/224 passed (a few TK1-only tests are excluded there)
- [x] `swift test` on macOS host: 204/204 passed
- [x] `swiftlint --strict` and `swiftformat --lint` clean on touched files
- [x] `.github/workflows/ci.yml` YAML syntax validated

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01DQkyw2CFgSnkstoW7TDrA2