### PR TITLE
test: replace tautological CDMarkdownText assertions with real coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - CI now runs the full test suite against real iOS, tvOS, and visionOS simulators, in addition to the existing build-only checks for those platforms.
+- Replaced near-tautological `CDMarkdownText` SwiftUI tests (which only asserted the view's type) with real coverage of its parser-selection precedence and its `NSAttributedString`-to-`AttributedString` conversion, following the existing `CDMarkdownLabel` pattern of exposing testable seams as `internal` rather than adding a view-inspection dependency.
 
 ### Fixed
 

--- a/Source/CDMarkdownText.swift
+++ b/Source/CDMarkdownText.swift
@@ -10,7 +10,20 @@ public struct CDMarkdownText: View {
     @State private var attributedString: AttributedString = AttributedString()
 
     private var parser: CDMarkdownParser {
-        explicitParser ?? environmentParser ?? CDMarkdownParser(theme: environmentTheme)
+        Self.resolveParser(explicit: explicitParser, environment: environmentParser, theme: environmentTheme)
+    }
+
+    /// Picks the parser `body` renders with: an explicitly-injected parser always wins,
+    /// then an environment-injected one, falling back to a fresh parser built from `theme`.
+    /// Pulled out as a pure, `internal` function (rather than left as a `private` computed
+    /// property reading `@Environment` directly) so it's reachable from `@testable import`
+    /// without hosting the view — this project has no SwiftUI view-inspection dependency.
+    internal static func resolveParser(
+        explicit: CDMarkdownParser?,
+        environment: CDMarkdownParser?,
+        theme: CDMarkdownTheme
+    ) -> CDMarkdownParser {
+        explicit ?? environment ?? CDMarkdownParser(theme: theme)
     }
 
     /// Captures the identity of the effective parser so `.task` restarts whenever

--- a/Source/CDMarkdownText.swift
+++ b/Source/CDMarkdownText.swift
@@ -57,11 +57,19 @@ public struct CDMarkdownText: View {
         Text(attributedString)
             .task(id: taskID) {
                 let nsAttributed = await parser.parse(string)
-                #if os(macOS)
-                    attributedString = (try? AttributedString(nsAttributed, including: \.appKit)) ?? AttributedString(string)
-                #else
-                    attributedString = (try? AttributedString(nsAttributed, including: \.uiKit)) ?? AttributedString(string)
-                #endif
+                attributedString = Self.convert(nsAttributed, fallback: string)
             }
+    }
+
+    /// Converts the parser's `NSAttributedString` output into the `AttributedString` that
+    /// `Text` actually renders, falling back to the plain (unstyled) source string if the
+    /// scoped conversion fails. Pulled out as a pure, `internal` function so the real
+    /// parse → convert pipeline is testable via `@testable import` without hosting the view.
+    internal static func convert(_ nsAttributedString: NSAttributedString, fallback string: String) -> AttributedString {
+        #if os(macOS)
+            (try? AttributedString(nsAttributedString, including: \.appKit)) ?? AttributedString(string)
+        #else
+            (try? AttributedString(nsAttributedString, including: \.uiKit)) ?? AttributedString(string)
+        #endif
     }
 }

--- a/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownTextTests.swift
+++ b/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownTextTests.swift
@@ -13,10 +13,26 @@ struct CDMarkdownTextTests {
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, visionOS 1.0, *)
-    @Test func cdMarkdownTextAcceptsExplicitParser() {
-        let parser = CDMarkdownParser()
-        let view = CDMarkdownText("Hello", parser: parser)
-        #expect(type(of: view) == CDMarkdownText.self)
+    @Test func resolveParserPrefersExplicitOverEnvironmentAndDefault() {
+        let explicit = CDMarkdownParser()
+        let environment = CDMarkdownParser()
+        let resolved = CDMarkdownText.resolveParser(explicit: explicit, environment: environment, theme: .default)
+        #expect(resolved === explicit)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, visionOS 1.0, *)
+    @Test func resolveParserPrefersEnvironmentOverDefault() {
+        let environment = CDMarkdownParser()
+        let resolved = CDMarkdownText.resolveParser(explicit: nil, environment: environment, theme: .default)
+        #expect(resolved === environment)
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, visionOS 1.0, *)
+    @Test func resolveParserFallsBackToThemedDefault() {
+        var theme = CDMarkdownTheme.default
+        theme.fontColor = .red
+        let resolved = CDMarkdownText.resolveParser(explicit: nil, environment: nil, theme: theme)
+        #expect(resolved.fontColor == theme.fontColor)
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, visionOS 1.0, *)

--- a/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownTextTests.swift
+++ b/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownTextTests.swift
@@ -6,10 +6,27 @@ import Testing
 struct CDMarkdownTextTests {
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, visionOS 1.0, *)
-    @Test func cdMarkdownTextInitializesWithString() {
-        let view = CDMarkdownText("Hello **world**")
-        // Verify the view can be created without crashing
-        #expect(type(of: view) == CDMarkdownText.self)
+    @Test func convertProducesPlainTextWithMarkdownStripped() async {
+        let nsAttributed = await CDMarkdownParser().parse("Hello **world**")
+        let converted = CDMarkdownText.convert(nsAttributed, fallback: "Hello **world**")
+        #expect(String(converted.characters) == "Hello world")
+    }
+
+    @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, visionOS 1.0, *)
+    @Test func convertPreservesBoldFormatting() async {
+        let nsAttributed = await CDMarkdownParser().parse("Hello **world**")
+        let converted = CDMarkdownText.convert(nsAttributed, fallback: "Hello **world**")
+
+        let boldRunExists = converted.runs.contains { run in
+            let substring = String(converted[run.range].characters)
+            guard substring == "world" else { return false }
+            #if os(macOS)
+                return run.appKit.font?.fontDescriptor.symbolicTraits.contains(.bold) ?? false
+            #else
+                return run.uiKit.font?.fontDescriptor.symbolicTraits.contains(.traitBold) ?? false
+            #endif
+        }
+        #expect(boldRunExists)
     }
 
     @available(iOS 15.0, tvOS 15.0, macOS 12.0, watchOS 8.0, visionOS 1.0, *)


### PR DESCRIPTION
### Issue :link:

Closes #63

### Goals :soccer:

- Replace `CDMarkdownTextTests.swift`'s near-tautological assertions (`#expect(type(of: view) == CDMarkdownText.self)`, true for any successfully-constructed view) with tests that verify real behavior.
- Do this without adding a SwiftUI view-inspection dependency (e.g. ViewInspector), preserving CDMarkdownKit's zero-dependency positioning.

### Implementation Details :construction:

`CDMarkdownText` had no inspectable rendering surface, so two previously-inline, private behaviors were pulled out as pure `internal static` functions — reachable via `@testable import` without hosting the view, following the same pattern already used in `CDMarkdownLabel` for testable seams:

- `resolveParser(explicit:environment:theme:)` — the parser-selection precedence (explicit > environment > themed default) that used to live only inside a private computed property.
- `convert(_:fallback:)` — the `NSAttributedString` → `AttributedString` conversion that `Text` actually renders, previously inlined in the `.task` closure.

`body` now calls both functions instead of embedding the logic directly; behavior is unchanged.

`CDMarkdownView.swift` has its own, larger test-coverage gap (currently zero tests) — deliberately out of scope here; happy to file a follow-up issue if wanted.

### Testing Details :mag:

- Replaced 2 of 4 existing tests, kept 2 that already asserted real behavior.
- New: `resolveParserPrefersExplicitOverEnvironmentAndDefault`, `resolveParserPrefersEnvironmentOverDefault`, `resolveParserFallsBackToThemedDefault`, `convertProducesPlainTextWithMarkdownStripped`, `convertPreservesBoldFormatting`.
- `convertPreservesBoldFormatting` exercises the real `CDMarkdownParser` parse pipeline and checks bold font traits survive the scoped `AttributedString` conversion on both the `appKit` and `uiKit` branches (verified via a staged `xcodebuild test` run on iOS, per this repo's documented procedure for UIKit-gated tests).
- `swift test`: 207/207 pass. `swiftformat --lint` / `swiftlint --strict`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qs4CYH2nupqGm8G5EHwQC