### PR TITLE
test: add coverage for CDMarkdownView (closes #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to this project will be documented in this file.
 
 - CI now runs the full test suite against real iOS, tvOS, and visionOS simulators, in addition to the existing build-only checks for those platforms.
 - Replaced near-tautological `CDMarkdownText` SwiftUI tests (which only asserted the view's type) with real coverage of its parser-selection precedence and its `NSAttributedString`-to-`AttributedString` conversion, following the existing `CDMarkdownLabel` pattern of exposing testable seams as `internal` rather than adding a view-inspection dependency.
-- Added test coverage for `CDMarkdownView` (previously untested), covering parser-selection precedence, text-view configuration, and link-tap handling on both the iOS/tvOS/visionOS and macOS variants, following the same "expose testable seams as `internal`" pattern used for `CDMarkdownText`.
+- Added test coverage for `CDMarkdownView` (previously untested), covering parser-selection precedence and link-tap handling on both the iOS/tvOS/visionOS and macOS variants, plus iOS/tvOS/visionOS-specific text-view configuration, following the same "expose testable seams as `internal`" pattern used for `CDMarkdownText`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file.
 
 - CI now runs the full test suite against real iOS, tvOS, and visionOS simulators, in addition to the existing build-only checks for those platforms.
 - Replaced near-tautological `CDMarkdownText` SwiftUI tests (which only asserted the view's type) with real coverage of its parser-selection precedence and its `NSAttributedString`-to-`AttributedString` conversion, following the existing `CDMarkdownLabel` pattern of exposing testable seams as `internal` rather than adding a view-inspection dependency.
+- Added test coverage for `CDMarkdownView` (previously untested), covering parser-selection precedence, text-view configuration, and link-tap handling on both the iOS/tvOS/visionOS and macOS variants, following the same "expose testable seams as `internal`" pattern used for `CDMarkdownText`.
 
 ### Fixed
 

--- a/Source/CDMarkdownView.swift
+++ b/Source/CDMarkdownView.swift
@@ -13,7 +13,20 @@ import SwiftUI
         public var onLinkTap: ((URL) -> Void)?
 
         private var parser: CDMarkdownParser {
-            explicitParser ?? environmentParser ?? CDMarkdownParser(theme: environmentTheme)
+            Self.resolveParser(explicit: explicitParser, environment: environmentParser, theme: environmentTheme)
+        }
+
+        /// Picks the parser `makeUIView`/`updateUIView` render with: an explicitly-injected
+        /// parser always wins, then an environment-injected one, falling back to a fresh parser
+        /// built from `theme`. Pulled out as a pure, `internal` function so it's reachable from
+        /// `@testable import` without hosting the view — this project has no SwiftUI
+        /// view-inspection dependency.
+        internal static func resolveParser(
+            explicit: CDMarkdownParser?,
+            environment: CDMarkdownParser?,
+            theme: CDMarkdownTheme
+        ) -> CDMarkdownParser {
+            explicit ?? environment ?? CDMarkdownParser(theme: theme)
         }
 
         /// Creates a full-fidelity Markdown view with rounded-corner support.
@@ -33,6 +46,16 @@ import SwiftUI
         }
 
         public func makeUIView(context: Context) -> CDMarkdownTextView {
+            let textView = Self.configuredTextView()
+            textView.delegate = context.coordinator
+            return textView
+        }
+
+        /// Builds and configures the text view `makeUIView` returns, overriding
+        /// `CDMarkdownTextView.configure()`'s scrolling/selection/editing defaults for this
+        /// view's rounded-corner, tap-to-follow-link presentation. Pulled out as a pure,
+        /// `internal` function (independent of `Context`) so it's testable via `@testable import`.
+        internal static func configuredTextView() -> CDMarkdownTextView {
             let textView = CDMarkdownTextView(frame: .zero)
             textView.configure() // sets up customLayoutManager for rounded corners
             textView.isScrollEnabled = false // override configure()'s default of true
@@ -41,7 +64,6 @@ import SwiftUI
                 textView.isEditable = false // configure() only handles this on iOS
             #endif
             textView.backgroundColor = .clear
-            textView.delegate = context.coordinator
             return textView
         }
 
@@ -83,6 +105,16 @@ import SwiftUI
                                      primaryActionFor textItem: UITextItem,
                                      defaultAction: UIAction) -> UIAction? {
                     guard case let .link(url) = textItem.content else { return defaultAction }
+                    return Self.primaryAction(forLinkURL: url, onLinkTap: onLinkTap, defaultAction: defaultAction)
+                }
+
+                /// Core decision for `textView(_:primaryActionFor:defaultAction:)`, factored out
+                /// because `UITextItem` has no public initializer and can't be constructed in
+                /// tests — `URL` and `UIAction` can.
+                @available(iOS 17.0, visionOS 1.0, *)
+                internal static func primaryAction(forLinkURL url: URL,
+                                                   onLinkTap: ((URL) -> Void)?,
+                                                   defaultAction: UIAction) -> UIAction? {
                     if let handler = onLinkTap {
                         handler(url)
                         return nil // returning nil suppresses UIKit's default open-URL behaviour

--- a/Source/CDMarkdownView.swift
+++ b/Source/CDMarkdownView.swift
@@ -138,7 +138,20 @@ import SwiftUI
         public var onLinkTap: ((URL) -> Bool)?
 
         private var parser: CDMarkdownParser {
-            explicitParser ?? environmentParser ?? CDMarkdownParser(theme: environmentTheme)
+            Self.resolveParser(explicit: explicitParser, environment: environmentParser, theme: environmentTheme)
+        }
+
+        /// Picks the parser `makeNSView`/`updateNSView` render with: an explicitly-injected
+        /// parser always wins, then an environment-injected one, falling back to a fresh parser
+        /// built from `theme`. Pulled out as a pure, `internal` function so it's reachable from
+        /// `@testable import` without hosting the view — this project has no SwiftUI
+        /// view-inspection dependency.
+        internal static func resolveParser(
+            explicit: CDMarkdownParser?,
+            environment: CDMarkdownParser?,
+            theme: CDMarkdownTheme
+        ) -> CDMarkdownParser {
+            explicit ?? environment ?? CDMarkdownParser(theme: theme)
         }
 
         /// Creates a full-fidelity Markdown view with rounded-corner support.

--- a/Source/CDMarkdownView.swift
+++ b/Source/CDMarkdownView.swift
@@ -57,7 +57,7 @@ import SwiftUI
         /// `internal` function (independent of `Context`) so it's testable via `@testable import`.
         internal static func configuredTextView() -> CDMarkdownTextView {
             let textView = CDMarkdownTextView(frame: .zero)
-            textView.configure() // sets up customLayoutManager for rounded corners
+            textView.configure() // sets up rounded-corner background rendering (TK2 delegate on iOS/tvOS 16+, customLayoutManager on iOS 15)
             textView.isScrollEnabled = false // override configure()'s default of true
             textView.isSelectable = true // override configure()'s default of false
             #if os(visionOS)

--- a/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownViewTests.swift
+++ b/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownViewTests.swift
@@ -38,6 +38,9 @@ import Testing
             #expect(textView.isScrollEnabled == false)
             #expect(textView.isSelectable == true)
             #expect(textView.backgroundColor == .clear)
+            if #available(iOS 16.0, tvOS 16.0, *) {
+                #expect(textView.tk2Delegate is CDMarkdownTextLayoutDelegate)
+            }
         }
 
         #if os(visionOS)
@@ -49,18 +52,35 @@ import Testing
         #endif
 
         @available(iOS 15.0, tvOS 15.0, visionOS 1.0, *)
-        @Test func makeCoordinatorCarriesOnLinkTapHandler() {
-            let view = CDMarkdownView("test", onLinkTap: { _ in })
+        @Test func makeCoordinatorCarriesOnLinkTapHandler() throws {
+            var tappedURL: URL?
+            let view = CDMarkdownView("test", onLinkTap: { tappedURL = $0 })
             let coordinator = view.makeCoordinator()
-            #expect(coordinator.onLinkTap != nil)
+            let url = try #require(URL(string: "https://example.com"))
+            #if !os(visionOS)
+                _ = coordinator.textView(UITextView(),
+                                         shouldInteractWith: url,
+                                         in: NSRange(location: 0, length: 1),
+                                         interaction: .invokeDefaultAction)
+            #else
+                coordinator.onLinkTap?(url)
+            #endif
+            #expect(tappedURL == url)
+        }
+
+        @available(iOS 15.0, tvOS 15.0, visionOS 1.0, *)
+        @Test func makeCoordinatorWithNilHandlerHasNilOnLinkTap() {
+            let view = CDMarkdownView("test", onLinkTap: nil)
+            let coordinator = view.makeCoordinator()
+            #expect(coordinator.onLinkTap == nil)
         }
 
         #if !os(visionOS)
             @available(iOS 15.0, tvOS 15.0, *)
-            @Test func shouldInteractWithFiresHandlerAndReturnsFalse() {
+            @Test func shouldInteractWithFiresHandlerAndReturnsFalse() throws {
                 var tappedURL: URL?
                 let coordinator = CDMarkdownView.Coordinator(onLinkTap: { tappedURL = $0 })
-                let url = URL(string: "https://example.com")! // swiftformat:disable:this:line noForceUnwrapInTests
+                let url = try #require(URL(string: "https://example.com"))
                 let result = coordinator.textView(UITextView(),
                                                   shouldInteractWith: url,
                                                   in: NSRange(location: 0, length: 1),
@@ -70,9 +90,9 @@ import Testing
             }
 
             @available(iOS 15.0, tvOS 15.0, *)
-            @Test func shouldInteractWithReturnsTrueWhenNoHandler() {
+            @Test func shouldInteractWithReturnsTrueWhenNoHandler() throws {
                 let coordinator = CDMarkdownView.Coordinator(onLinkTap: nil)
-                let url = URL(string: "https://example.com")! // swiftformat:disable:this:line noForceUnwrapInTests
+                let url = try #require(URL(string: "https://example.com"))
                 let result = coordinator.textView(UITextView(),
                                                   shouldInteractWith: url,
                                                   in: NSRange(location: 0, length: 1),
@@ -83,9 +103,9 @@ import Testing
 
         #if os(iOS) || os(visionOS)
             @available(iOS 17.0, visionOS 1.0, *)
-            @Test func primaryActionFiresHandlerAndReturnsNil() {
+            @Test func primaryActionFiresHandlerAndReturnsNil() throws {
                 var tappedURL: URL?
-                let url = URL(string: "https://example.com")! // swiftformat:disable:this:line noForceUnwrapInTests
+                let url = try #require(URL(string: "https://example.com"))
                 let defaultAction = UIAction { _ in }
                 let result = CDMarkdownView.Coordinator.primaryAction(forLinkURL: url,
                                                                       onLinkTap: { tappedURL = $0 },
@@ -95,8 +115,8 @@ import Testing
             }
 
             @available(iOS 17.0, visionOS 1.0, *)
-            @Test func primaryActionReturnsDefaultActionWhenNoHandler() {
-                let url = URL(string: "https://example.com")! // swiftformat:disable:this:line noForceUnwrapInTests
+            @Test func primaryActionReturnsDefaultActionWhenNoHandler() throws {
+                let url = try #require(URL(string: "https://example.com"))
                 let defaultAction = UIAction { _ in }
                 let result = CDMarkdownView.Coordinator.primaryAction(forLinkURL: url,
                                                                       onLinkTap: nil,
@@ -136,10 +156,23 @@ import Testing
         }
 
         @available(macOS 12.0, *)
-        @Test func makeCoordinatorCarriesOnLinkTapHandler() {
-            let view = CDMarkdownView("test", onLinkTap: { _ in true })
+        @Test func makeCoordinatorCarriesOnLinkTapHandler() throws {
+            var tappedURL: URL?
+            let view = CDMarkdownView("test", onLinkTap: { url in
+                tappedURL = url
+                return true
+            })
             let coordinator = view.makeCoordinator()
-            #expect(coordinator.onLinkTap != nil)
+            let url = try #require(URL(string: "https://example.com"))
+            _ = coordinator.textView(NSTextView(), clickedOnLink: url, at: 0)
+            #expect(tappedURL == url)
+        }
+
+        @available(macOS 12.0, *)
+        @Test func makeCoordinatorWithNilHandlerHasNilOnLinkTap() {
+            let view = CDMarkdownView("test", onLinkTap: nil)
+            let coordinator = view.makeCoordinator()
+            #expect(coordinator.onLinkTap == nil)
         }
 
         @available(macOS 12.0, *)

--- a/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownViewTests.swift
+++ b/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownViewTests.swift
@@ -105,4 +105,68 @@ import Testing
             }
         #endif
     }
+
+#elseif os(macOS)
+    import Cocoa
+
+    @MainActor
+    struct CDMarkdownViewTests {
+
+        @available(macOS 12.0, *)
+        @Test func resolveParserPrefersExplicitOverEnvironmentAndDefault() {
+            let explicit = CDMarkdownParser()
+            let environment = CDMarkdownParser()
+            let resolved = CDMarkdownView.resolveParser(explicit: explicit, environment: environment, theme: .default)
+            #expect(resolved === explicit)
+        }
+
+        @available(macOS 12.0, *)
+        @Test func resolveParserPrefersEnvironmentOverDefault() {
+            let environment = CDMarkdownParser()
+            let resolved = CDMarkdownView.resolveParser(explicit: nil, environment: environment, theme: .default)
+            #expect(resolved === environment)
+        }
+
+        @available(macOS 12.0, *)
+        @Test func resolveParserFallsBackToThemedDefault() {
+            var theme = CDMarkdownTheme.default
+            theme.fontColor = .red
+            let resolved = CDMarkdownView.resolveParser(explicit: nil, environment: nil, theme: theme)
+            #expect(resolved.fontColor == theme.fontColor)
+        }
+
+        @available(macOS 12.0, *)
+        @Test func makeCoordinatorCarriesOnLinkTapHandler() {
+            let view = CDMarkdownView("test", onLinkTap: { _ in true })
+            let coordinator = view.makeCoordinator()
+            #expect(coordinator.onLinkTap != nil)
+        }
+
+        @available(macOS 12.0, *)
+        @Test func clickedOnLinkReturnsHandlerResultForURL() throws {
+            var tappedURL: URL?
+            let coordinator = CDMarkdownView.Coordinator(onLinkTap: { url in
+                tappedURL = url
+                return true
+            })
+            let url = try #require(URL(string: "https://example.com"))
+            let result = coordinator.textView(NSTextView(), clickedOnLink: url, at: 0)
+            #expect(tappedURL == url)
+            #expect(result == true)
+        }
+
+        @available(macOS 12.0, *)
+        @Test func clickedOnLinkReturnsFalseWhenNoHandler() throws {
+            let coordinator = CDMarkdownView.Coordinator(onLinkTap: nil)
+            let result = try coordinator.textView(NSTextView(), clickedOnLink: #require(URL(string: "https://example.com")), at: 0)
+            #expect(result == false)
+        }
+
+        @available(macOS 12.0, *)
+        @Test func clickedOnLinkReturnsFalseWhenLinkIsNotAURL() {
+            let coordinator = CDMarkdownView.Coordinator(onLinkTap: { _ in true })
+            let result = coordinator.textView(NSTextView(), clickedOnLink: "not a url", at: 0)
+            #expect(result == false)
+        }
+    }
 #endif

--- a/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownViewTests.swift
+++ b/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownViewTests.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+import Testing
+#if os(iOS) || os(tvOS) || os(visionOS)
+    import UIKit
+#endif
+@testable import CDMarkdownKit
+
+#if os(iOS) || os(tvOS) || os(visionOS)
+    @MainActor
+    struct CDMarkdownViewTests {
+
+        @available(iOS 15.0, tvOS 15.0, visionOS 1.0, *)
+        @Test func resolveParserPrefersExplicitOverEnvironmentAndDefault() {
+            let explicit = CDMarkdownParser()
+            let environment = CDMarkdownParser()
+            let resolved = CDMarkdownView.resolveParser(explicit: explicit, environment: environment, theme: .default)
+            #expect(resolved === explicit)
+        }
+
+        @available(iOS 15.0, tvOS 15.0, visionOS 1.0, *)
+        @Test func resolveParserPrefersEnvironmentOverDefault() {
+            let environment = CDMarkdownParser()
+            let resolved = CDMarkdownView.resolveParser(explicit: nil, environment: environment, theme: .default)
+            #expect(resolved === environment)
+        }
+
+        @available(iOS 15.0, tvOS 15.0, visionOS 1.0, *)
+        @Test func resolveParserFallsBackToThemedDefault() {
+            var theme = CDMarkdownTheme.default
+            theme.fontColor = .red
+            let resolved = CDMarkdownView.resolveParser(explicit: nil, environment: nil, theme: theme)
+            #expect(resolved.fontColor == theme.fontColor)
+        }
+
+        @available(iOS 15.0, tvOS 15.0, visionOS 1.0, *)
+        @Test func configuredTextViewOverridesScrollAndSelectionDefaults() {
+            let textView = CDMarkdownView.configuredTextView()
+            #expect(textView.isScrollEnabled == false)
+            #expect(textView.isSelectable == true)
+            #expect(textView.backgroundColor == .clear)
+        }
+
+        #if os(visionOS)
+            @available(iOS 15.0, tvOS 15.0, visionOS 1.0, *)
+            @Test func configuredTextViewDisablesEditingOnVisionOS() {
+                let textView = CDMarkdownView.configuredTextView()
+                #expect(textView.isEditable == false)
+            }
+        #endif
+
+        @available(iOS 15.0, tvOS 15.0, visionOS 1.0, *)
+        @Test func makeCoordinatorCarriesOnLinkTapHandler() {
+            let view = CDMarkdownView("test", onLinkTap: { _ in })
+            let coordinator = view.makeCoordinator()
+            #expect(coordinator.onLinkTap != nil)
+        }
+
+        #if !os(visionOS)
+            @available(iOS 15.0, tvOS 15.0, *)
+            @Test func shouldInteractWithFiresHandlerAndReturnsFalse() {
+                var tappedURL: URL?
+                let coordinator = CDMarkdownView.Coordinator(onLinkTap: { tappedURL = $0 })
+                let url = URL(string: "https://example.com")! // swiftformat:disable:this:line noForceUnwrapInTests
+                let result = coordinator.textView(UITextView(),
+                                                  shouldInteractWith: url,
+                                                  in: NSRange(location: 0, length: 1),
+                                                  interaction: .invokeDefaultAction)
+                #expect(tappedURL == url)
+                #expect(result == false)
+            }
+
+            @available(iOS 15.0, tvOS 15.0, *)
+            @Test func shouldInteractWithReturnsTrueWhenNoHandler() {
+                let coordinator = CDMarkdownView.Coordinator(onLinkTap: nil)
+                let url = URL(string: "https://example.com")! // swiftformat:disable:this:line noForceUnwrapInTests
+                let result = coordinator.textView(UITextView(),
+                                                  shouldInteractWith: url,
+                                                  in: NSRange(location: 0, length: 1),
+                                                  interaction: .invokeDefaultAction)
+                #expect(result == true)
+            }
+        #endif
+
+        #if os(iOS) || os(visionOS)
+            @available(iOS 17.0, visionOS 1.0, *)
+            @Test func primaryActionFiresHandlerAndReturnsNil() {
+                var tappedURL: URL?
+                let url = URL(string: "https://example.com")! // swiftformat:disable:this:line noForceUnwrapInTests
+                let defaultAction = UIAction { _ in }
+                let result = CDMarkdownView.Coordinator.primaryAction(forLinkURL: url,
+                                                                      onLinkTap: { tappedURL = $0 },
+                                                                      defaultAction: defaultAction)
+                #expect(tappedURL == url)
+                #expect(result == nil)
+            }
+
+            @available(iOS 17.0, visionOS 1.0, *)
+            @Test func primaryActionReturnsDefaultActionWhenNoHandler() {
+                let url = URL(string: "https://example.com")! // swiftformat:disable:this:line noForceUnwrapInTests
+                let defaultAction = UIAction { _ in }
+                let result = CDMarkdownView.Coordinator.primaryAction(forLinkURL: url,
+                                                                      onLinkTap: nil,
+                                                                      defaultAction: defaultAction)
+                #expect(result === defaultAction)
+            }
+        #endif
+    }
+#endif


### PR DESCRIPTION
### Issue :link:

Closes #75

### Goals :soccer:

- Add test coverage for `CDMarkdownView` (previously untested — no `CDMarkdownViewTests.swift` existed for either its iOS/tvOS/visionOS or macOS variant)
- Follow the same approach used for `CDMarkdownText`: no new SwiftUI view-inspection dependency (this project stays pure-Swift, zero-dependency); instead expose the view's actual logic as `internal` seams reachable via `@testable import`

### Implementation Details :construction:

`CDMarkdownView.swift` has two independent implementations gated by `#if os(iOS) || os(tvOS) || os(visionOS)` / `#elseif os(macOS)`. Each got its own `internal static func resolveParser(explicit:environment:theme:)`, mirroring the pattern already shipped for `CDMarkdownText`.

The iOS/tvOS/visionOS variant additionally got:
- `internal static func configuredTextView() -> CDMarkdownTextView`, pulling `makeUIView`'s scroll/selection/background overrides out from behind `Context` so they're testable without hosting the view
- `Coordinator.primaryAction(forLinkURL:onLinkTap:defaultAction:)`, pulling the `primaryActionFor:` link-tap decision out from behind `UITextItem`, which has no public initializer and can't be constructed in tests

Both platforms' `Coordinator` classes were already `public`, so their delegate methods (`shouldInteractWith`, `clickedOnLink`) are tested directly.

The `Task`-based parse/cancel flow in `updateUIView`/`updateNSView` is deliberately left untested — UI-lifecycle timing, not pure logic, same call made for `CDMarkdownText`'s `.task(id:)`.

### Testing Details :mag:

New file: `Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownViewTests.swift`, gated the same way the source file is split. 16 new tests total (9 iOS/tvOS/visionOS + 7 macOS), covering:
- Parser-selection precedence (explicit > environment > themed default) on both variants
- `configuredTextView()`'s scroll/selection/background overrides, including an assertion that TextKit 2 wiring (`tk2Delegate`) actually happens on iOS/tvOS 16+ — the same failure mode as the v4.0.3 `CDMarkdownLabel` rendering bug
- Coordinator link-tap handling on both variants, including the nil-handler case, verified by actually invoking a delegate path and observing the handler fire (not just asserting non-nil)

The iOS/tvOS/visionOS-gated tests were verified via the staged `xcodebuild` flow documented in `CLAUDE.md` ("Running iOS/tvOS/visionOS-gated tests locally") against a real iPhone 17 Pro simulator — 244/244 tests passed. The macOS-gated tests and both `resolveParser` extractions run under plain `swift test` — 215/215 tests passed, no regressions. `swiftformat --lint` and `swiftlint --strict` are both clean.