### PR TITLE
refactor: collapse CDMarkdownLabel's TK2 state into one atomic stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
 - Replaced near-tautological `CDMarkdownText` SwiftUI tests (which only asserted the view's type) with real coverage of its parser-selection precedence and its `NSAttributedString`-to-`AttributedString` conversion, following the existing `CDMarkdownLabel` pattern of exposing testable seams as `internal` rather than adding a view-inspection dependency.
 - Added test coverage for `CDMarkdownView` (previously untested), covering parser-selection precedence and link-tap handling on both the iOS/tvOS/visionOS and macOS variants, plus iOS/tvOS/visionOS-specific text-view configuration, following the same "expose testable seams as `internal`" pattern used for `CDMarkdownText`.
 
+### Changed
+
+- Collapsed `CDMarkdownLabel`'s three independent TextKit 2 state properties (`tk2LayoutManager`, `tk2ContentStorage`, `tk2LayoutDelegate`) into a single atomic `tk2Stack`, so every dispatch site checks one thing instead of downcasting whichever of the three it happens to need — eliminating a bug class where the three could drift out of sync.
+
 ### Fixed
 
 - Fixed several test files failing to compile for visionOS, due to a platform check that predated visionOS support and was never updated to include it.

--- a/Source/CDMarkdownLabel.swift
+++ b/Source/CDMarkdownLabel.swift
@@ -65,17 +65,21 @@
         /// The custom text storage that holds the attributed text and layout information.
         open var customTextStorage: NSTextStorage!
 
-        /// Holds an NSTextLayoutManager on iOS/tvOS 16+. Internal (not `private`) so tests can
-        /// inspect and force TextKit 2 wiring via `@testable import`.
-        internal var tk2LayoutManager: Any?
+        /// Bundles the three objects that make up the TextKit 2 stack, so every dispatch site
+        /// checks one thing instead of independently downcasting whichever of the three it
+        /// happens to need — the previous split let the objects drift out of sync with each
+        /// other. Internal (not `private`) so tests can inspect its fields via `@testable import`.
+        @available(iOS 16.0, tvOS 16.0, *)
+        internal struct TK2Stack {
+            let contentStorage: NSTextContentStorage
+            let layoutManager: NSTextLayoutManager
+            let delegate: CDMarkdownTextLayoutDelegate
+        }
 
-        /// Holds an NSTextContentStorage on iOS/tvOS 16+. Internal (not `private`) so tests can
-        /// inspect and force TextKit 2 wiring via `@testable import`.
-        internal var tk2ContentStorage: Any?
-
-        /// Holds a CDMarkdownTextLayoutDelegate on iOS/tvOS 16+. Internal (not `private`) so tests can
-        /// inspect and force TextKit 2 wiring via `@testable import`.
-        internal var tk2LayoutDelegate: Any?
+        /// Holds a `TK2Stack` on iOS/tvOS 16+. Type-erased to `Any?` so the property can exist
+        /// unconditionally (the stack type itself is `@available`). Internal (not `private`) so
+        /// tests can inspect and force TextKit 2 wiring via `@testable import`.
+        internal var tk2Stack: Any?
 
         /// Delegate that receives callbacks when links in the label are tapped.
         /// Set this to handle link navigation, e.g., opening URLs in Safari.
@@ -90,8 +94,8 @@
         open var roundAllCorners: Bool = false {
             didSet {
                 if #available(iOS 16.0, tvOS 16.0, *),
-                   let delegate = tk2LayoutDelegate as? CDMarkdownTextLayoutDelegate {
-                    delegate.roundAllCorners = roundAllCorners
+                   let stack = tk2Stack as? TK2Stack {
+                    stack.delegate.roundAllCorners = roundAllCorners
                 } else {
                     if let layoutManager = self.customLayoutManager {
                         layoutManager.roundAllCorners = roundAllCorners
@@ -131,8 +135,8 @@
                 guard let newValue else {
                     urlRanges.removeAll()
                     if #available(iOS 16.0, tvOS 16.0, *),
-                       let contentStorage = tk2ContentStorage as? NSTextContentStorage {
-                        contentStorage.textStorage?.setAttributedString(NSAttributedString())
+                       let stack = tk2Stack as? TK2Stack {
+                        stack.contentStorage.textStorage?.setAttributedString(NSAttributedString())
                     } else if let customTextStorage {
                         customTextStorage.setAttributedString(NSAttributedString())
                     }
@@ -146,12 +150,12 @@
                 parseTextAndExtractURLRanges(newValue)
 
                 if #available(iOS 16.0, tvOS 16.0, *),
-                   let contentStorage = tk2ContentStorage as? NSTextContentStorage {
-                    if let textStorage = contentStorage.textStorage {
+                   let stack = tk2Stack as? TK2Stack {
+                    if let textStorage = stack.contentStorage.textStorage {
                         textStorage.setAttributedString(newValue)
                     } else {
                         let textStorage = NSTextStorage(attributedString: newValue)
-                        contentStorage.textStorage = textStorage
+                        stack.contentStorage.textStorage = textStorage
                     }
                 } else if customTextContainer != nil,
                           let layoutManager = customLayoutManager {
@@ -225,9 +229,7 @@
             layoutManager.textContainer = customTextContainer
             contentStorage.addTextLayoutManager(layoutManager)
 
-            tk2ContentStorage = contentStorage
-            tk2LayoutManager = layoutManager
-            tk2LayoutDelegate = delegate
+            tk2Stack = TK2Stack(contentStorage: contentStorage, layoutManager: layoutManager, delegate: delegate)
         }
 
         /// Enumerates every text layout fragment in `layoutManager`'s document, forcing each
@@ -275,7 +277,7 @@
             self.customTextContainer.maximumNumberOfLines = numberOfLines
             // Measure the text with the new state
             var textBounds: CGRect
-            if #available(iOS 16.0, tvOS 16.0, *), let tk2 = tk2LayoutManager as? NSTextLayoutManager {
+            if #available(iOS 16.0, tvOS 16.0, *), let tk2 = (tk2Stack as? TK2Stack)?.layoutManager {
                 tk2.ensureLayout(for: tk2.documentRange)
                 textBounds = .zero
                 enumerateTK2Fragments(tk2) { fragment in
@@ -303,8 +305,8 @@
 
         override open func drawText(in rect: CGRect) {
             if #available(iOS 16.0, tvOS 16.0, *),
-               let tk2Manager = tk2LayoutManager as? NSTextLayoutManager {
-                drawTextTK2(in: rect, layoutManager: tk2Manager)
+               let stack = tk2Stack as? TK2Stack {
+                drawTextTK2(in: rect, layoutManager: stack.layoutManager)
             } else {
                 drawTextTK1(in: rect)
             }
@@ -342,7 +344,7 @@
             // Returns the XY offset of the range of glyphs from the view's origin
             var textOffset = CGPoint.zero
 
-            if #available(iOS 16.0, tvOS 16.0, *), let tk2 = tk2LayoutManager as? NSTextLayoutManager {
+            if #available(iOS 16.0, tvOS 16.0, *), let tk2 = (tk2Stack as? TK2Stack)?.layoutManager {
                 tk2.ensureLayout(for: tk2.documentRange)
                 var maxY: CGFloat = 0
                 enumerateTK2Fragments(tk2) { fragment in
@@ -526,9 +528,9 @@
         /// in a unit test.
         internal func urlRange(at location: CGPoint) -> URLRange? {
             if #available(iOS 16.0, tvOS 16.0, *),
-               let tk2Manager = tk2LayoutManager as? NSTextLayoutManager,
-               let textStorage = tk2Manager.textContentManager as? NSTextContentStorage {
-                urlRangeTK2(at: location, layoutManager: tk2Manager, storage: textStorage)
+               let stack = tk2Stack as? TK2Stack,
+               let textStorage = stack.layoutManager.textContentManager as? NSTextContentStorage {
+                urlRangeTK2(at: location, layoutManager: stack.layoutManager, storage: textStorage)
             } else {
                 urlRangeTK1(at: location)
             }

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownLabelTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownLabelTests.swift
@@ -32,9 +32,13 @@ import Testing
         @Test func configureTK2SetsUpContentStorageLayoutManagerAndDelegate() {
             let label = CDMarkdownLabel(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
             label.configureTK2()
-            #expect(label.tk2ContentStorage is NSTextContentStorage)
-            #expect(label.tk2LayoutManager is NSTextLayoutManager)
-            #expect(label.tk2LayoutDelegate is CDMarkdownTextLayoutDelegate)
+            guard let stack = label.tk2Stack as? CDMarkdownLabel.TK2Stack else {
+                Issue.record("expected a TK2Stack")
+                return
+            }
+            #expect(stack.contentStorage is NSTextContentStorage)
+            #expect(stack.layoutManager is NSTextLayoutManager)
+            #expect(stack.delegate is CDMarkdownTextLayoutDelegate)
         }
 
         @available(iOS 16.0, tvOS 16.0, *)
@@ -44,7 +48,7 @@ import Testing
             let parser = CDMarkdownParser()
             label.attributedText = parser.parse("[a link](https://example.com)")
 
-            guard let layoutManager = label.tk2LayoutManager as? NSTextLayoutManager else {
+            guard let layoutManager = (label.tk2Stack as? CDMarkdownLabel.TK2Stack)?.layoutManager else {
                 Issue.record("expected a TextKit 2 layout manager")
                 return
             }
@@ -71,7 +75,7 @@ import Testing
             let parser = CDMarkdownParser()
             label.attributedText = parser.parse("[a link](https://example.com)")
 
-            guard let layoutManager = label.tk2LayoutManager as? NSTextLayoutManager else {
+            guard let layoutManager = (label.tk2Stack as? CDMarkdownLabel.TK2Stack)?.layoutManager else {
                 Issue.record("expected a TextKit 2 layout manager")
                 return
             }
@@ -82,12 +86,9 @@ import Testing
 
         @Test func urlRangeAtLocationFindsLinkTK1() {
             let label = CDMarkdownLabel(frame: CGRect(x: 0, y: 0, width: 300, height: 100))
-            // Force the TK1 dispatch branch: urlRange(at:) routes on whether tk2LayoutManager
-            // holds an NSTextLayoutManager, while attributedText's setter routes separately on
-            // tk2ContentStorage, so both must be cleared before assigning attributedText.
-            label.tk2LayoutManager = nil
-            label.tk2ContentStorage = nil
-            label.tk2LayoutDelegate = nil
+            // Force the TK1 dispatch branch: every dispatch site routes on whether tk2Stack
+            // holds a TK2Stack, so clearing the one property is enough to force TK1 everywhere.
+            label.tk2Stack = nil
             label.configureTK1()
             let parser = CDMarkdownParser()
             label.attributedText = parser.parse("[a link](https://example.com)")
@@ -106,9 +107,7 @@ import Testing
 
         @Test func urlRangeAtLocationReturnsNilOutsideBoundingRectTK1() {
             let label = CDMarkdownLabel(frame: CGRect(x: 0, y: 0, width: 300, height: 100))
-            label.tk2LayoutManager = nil
-            label.tk2ContentStorage = nil
-            label.tk2LayoutDelegate = nil
+            label.tk2Stack = nil
             label.configureTK1()
             let parser = CDMarkdownParser()
             label.attributedText = parser.parse("[a link](https://example.com)")
@@ -124,7 +123,7 @@ import Testing
             label.configureTK2()
             label.roundAllCorners = true
 
-            guard let delegate = label.tk2LayoutDelegate as? CDMarkdownTextLayoutDelegate else {
+            guard let delegate = (label.tk2Stack as? CDMarkdownLabel.TK2Stack)?.delegate else {
                 Issue.record("expected a CDMarkdownTextLayoutDelegate")
                 return
             }
@@ -133,10 +132,10 @@ import Testing
 
         @Test func roundAllCornersPropagatesToTK1LayoutManagerWhenTK2NotConfigured() {
             let label = CDMarkdownLabel(frame: CGRect(x: 0, y: 0, width: 200, height: 100))
-            // roundAllCorners's didSet routes on whether tk2LayoutDelegate currently holds a
-            // CDMarkdownTextLayoutDelegate; clear it so the TK1 branch is exercised even
-            // though init() already ran configureTK2() on a modern simulator.
-            label.tk2LayoutDelegate = nil
+            // roundAllCorners's didSet routes on whether tk2Stack currently holds a TK2Stack;
+            // clear it so the TK1 branch is exercised even though init() already ran
+            // configureTK2() on a modern simulator.
+            label.tk2Stack = nil
             label.configureTK1()
             label.roundAllCorners = true
 
@@ -162,7 +161,7 @@ import Testing
             let paragraphs = (1 ... 40).map { "Paragraph \($0) with enough text to wrap across a couple of lines in a narrow label." }
             label.attributedText = parser.parse(paragraphs.joined(separator: "\n\n"))
 
-            guard let layoutManager = label.tk2LayoutManager as? NSTextLayoutManager else {
+            guard let layoutManager = (label.tk2Stack as? CDMarkdownLabel.TK2Stack)?.layoutManager else {
                 Issue.record("expected a TextKit 2 layout manager")
                 return
             }

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownTextLayoutManagerTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownTextLayoutManagerTests.swift
@@ -16,7 +16,7 @@ import Testing
             let parser = CDMarkdownParser()
             label.attributedText = parser.parse("plain `code` text")
 
-            guard let layoutManager = label.tk2LayoutManager as? NSTextLayoutManager else {
+            guard let layoutManager = (label.tk2Stack as? CDMarkdownLabel.TK2Stack)?.layoutManager else {
                 Issue.record("expected a TextKit 2 layout manager")
                 return
             }
@@ -40,7 +40,7 @@ import Testing
             let parser = CDMarkdownParser()
             label.attributedText = parser.parse("plain `code` text")
 
-            guard let layoutManager = label.tk2LayoutManager as? NSTextLayoutManager else {
+            guard let layoutManager = (label.tk2Stack as? CDMarkdownLabel.TK2Stack)?.layoutManager else {
                 Issue.record("expected a TextKit 2 layout manager")
                 return
             }
@@ -64,7 +64,7 @@ import Testing
             let parser = CDMarkdownParser()
             label.attributedText = parser.parse("plain `code` text")
 
-            guard let layoutManager = label.tk2LayoutManager as? NSTextLayoutManager else {
+            guard let layoutManager = (label.tk2Stack as? CDMarkdownLabel.TK2Stack)?.layoutManager else {
                 Issue.record("expected a TextKit 2 layout manager")
                 return
             }


### PR DESCRIPTION
## Summary
- Replaces `tk2LayoutManager`/`tk2ContentStorage`/`tk2LayoutDelegate` (three independent `Any?` properties) with a single `tk2Stack: Any?` holding a new `TK2Stack` struct (`contentStorage`, `layoutManager`, `delegate`).
- Every dispatch site (`roundAllCorners`'s `didSet`, `attributedText`'s getter/setter, `configureTK2()`, `textRect(forBounds:)`, `drawText(in:)`, `calculateGlyphsPositionInView()`, `urlRange(at:)`) now checks `tk2Stack as? TK2Stack` once, instead of independently downcasting whichever of the three properties that call site happened to use.
- Makes it structurally impossible for the three to disagree — the exact bug class that caused two real bugs during the TextKit 2 test-coverage work (a `configureTK2()` bug where all three silently stayed `nil`, and a test needing to clear two properties to force the TK1 path because two call sites checked two different properties).

Closes #69

## Test plan
- [x] `swift build` — clean
- [x] `swift test` — 215/215 tests pass
- [x] Staged-copy `xcodebuild test -scheme CDMarkdownKit-Package` against a real iOS 26.5 simulator (per CLAUDE.md's documented approach for TextKit-2-gated tests) — 15/15 tests in `CDMarkdownLabelTests` + `CDMarkdownTextLayoutManagerTests` pass
- [x] `swiftformat Source Tests --dryrun` — clean
- [x] `swiftlint lint --strict` on changed files — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qs4CYH2nupqGm8G5EHwQC