### PR TITLE
Fix roundAllCorners not retroactively updating already-laid-out TextKit 2 fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed several test files failing to compile for visionOS, due to a platform check that predated visionOS support and was never updated to include it.
 - Fixed `CDMarkdownLabel` rendering garbled, overlapping text on iOS/tvOS 16+ whenever its content was taller than the label's own bounds, such as a fixed-height label without a scroll view. TextKit 2 fragments beyond what fit the container were drawn at the wrong position instead of being cleanly excluded.
+- Fixed `CDMarkdownLabel`/`CDMarkdownTextView`'s `roundAllCorners` flag not retroactively rounding already-displayed code and syntax backgrounds on TextKit 2 (iOS/tvOS 16+) when toggled after `attributedText` had already been laid out. The corner-rounding flag is now read live at draw time instead of being cached on each text layout fragment when it was created, matching the behavior already present on the TextKit 1 fallback.
 
 ---
 

--- a/Source/CDMarkdownTextLayoutFragment.swift
+++ b/Source/CDMarkdownTextLayoutFragment.swift
@@ -2,6 +2,7 @@
     import UIKit
 
     @available(iOS 16.0, tvOS 16.0, *)
+    @MainActor
     final class CDMarkdownTextLayoutFragment: NSTextLayoutFragment {
 
         /// One rounded-corner background rectangle computed for a single attribute run within
@@ -11,7 +12,14 @@
             let color: UIColor
         }
 
-        var roundAllCorners: Bool = false
+        /// Read live from the owning layout manager's delegate at draw time — mirroring
+        /// `CDMarkdownLayoutManager`'s TextKit 1 approach — rather than cached on the fragment
+        /// at creation time. `NSTextLayoutManager` reuses already-created fragment instances
+        /// across `invalidateLayout(for:)`; a stored value snapshotted in the delegate's
+        /// factory method would never see a later toggle on already-laid-out content.
+        var roundAllCorners: Bool {
+            (textLayoutManager?.delegate as? CDMarkdownTextLayoutDelegate)?.roundAllCorners ?? false
+        }
 
         override func draw(at renderingOrigin: CGPoint, in context: CGContext) {
             if roundAllCorners {

--- a/Source/CDMarkdownTextLayoutFragment.swift
+++ b/Source/CDMarkdownTextLayoutFragment.swift
@@ -2,7 +2,6 @@
     import UIKit
 
     @available(iOS 16.0, tvOS 16.0, *)
-    @MainActor
     final class CDMarkdownTextLayoutFragment: NSTextLayoutFragment {
 
         /// One rounded-corner background rectangle computed for a single attribute run within
@@ -12,13 +11,15 @@
             let color: UIColor
         }
 
-        /// Read live from the owning layout manager's delegate at draw time — mirroring
-        /// `CDMarkdownLayoutManager`'s TextKit 1 approach — rather than cached on the fragment
-        /// at creation time. `NSTextLayoutManager` reuses already-created fragment instances
-        /// across `invalidateLayout(for:)`; a stored value snapshotted in the delegate's
-        /// factory method would never see a later toggle on already-laid-out content.
+        /// Shared with the `CDMarkdownTextLayoutDelegate` that created this fragment; see
+        /// `CDMarkdownRoundAllCornersBox`. Reading its `.value` live at draw time (rather than
+        /// copying a `Bool` onto this fragment at creation time) is what lets a `roundAllCorners`
+        /// toggle reach fragments `NSTextLayoutManager` already created and is reusing across an
+        /// `invalidateLayout(for:)`.
+        var roundAllCornersBox: CDMarkdownRoundAllCornersBox?
+
         var roundAllCorners: Bool {
-            (textLayoutManager?.delegate as? CDMarkdownTextLayoutDelegate)?.roundAllCorners ?? false
+            roundAllCornersBox?.value ?? false
         }
 
         override func draw(at renderingOrigin: CGPoint, in context: CGContext) {

--- a/Source/CDMarkdownTextLayoutManager.swift
+++ b/Source/CDMarkdownTextLayoutManager.swift
@@ -1,13 +1,33 @@
 #if os(iOS) || os(tvOS) || os(visionOS)
     import UIKit
 
+    /// Plain mutable reference shared between a `CDMarkdownTextLayoutDelegate` and every
+    /// `CDMarkdownTextLayoutFragment` it creates, so toggling `roundAllCorners` after fragments
+    /// already exist is visible to all of them without needing actor-isolated access at draw
+    /// time. `NSTextLayoutManager` reuses already-created fragment instances across
+    /// `invalidateLayout(for:)` rather than recreating them, so a value copied onto each
+    /// fragment at creation time would never see a later toggle; a shared reference always
+    /// reflects the delegate's current value. `roundAllCorners` is only ever written from the
+    /// delegate's `@MainActor` setter and only ever read from drawing code that UIKit guarantees
+    /// runs on the main thread, so the lack of actor isolation here is safe in practice despite
+    /// being unenforced by the compiler.
+    @available(iOS 16.0, tvOS 16.0, *)
+    final class CDMarkdownRoundAllCornersBox: @unchecked Sendable {
+        var value = false
+    }
+
     @available(iOS 16.0, tvOS 16.0, *)
     @MainActor
     final class CDMarkdownTextLayoutDelegate: NSObject, @preconcurrency NSTextLayoutManagerDelegate {
 
-        var roundAllCorners: Bool = false {
-            didSet {
-                guard oldValue != roundAllCorners, let manager = layoutManager else { return }
+        let roundAllCornersBox = CDMarkdownRoundAllCornersBox()
+
+        var roundAllCorners: Bool {
+            get { roundAllCornersBox.value }
+            set {
+                guard roundAllCornersBox.value != newValue else { return }
+                roundAllCornersBox.value = newValue
+                guard let manager = layoutManager else { return }
                 manager.invalidateLayout(for: manager.documentRange)
             }
         }
@@ -17,8 +37,10 @@
         func textLayoutManager(_ textLayoutManager: NSTextLayoutManager,
                                textLayoutFragmentFor location: any NSTextLocation,
                                in textElement: NSTextElement) -> NSTextLayoutFragment {
-            CDMarkdownTextLayoutFragment(textElement: textElement,
-                                         range: textElement.elementRange)
+            let fragment = CDMarkdownTextLayoutFragment(textElement: textElement,
+                                                        range: textElement.elementRange)
+            fragment.roundAllCornersBox = roundAllCornersBox
+            return fragment
         }
     }
 #endif

--- a/Source/CDMarkdownTextLayoutManager.swift
+++ b/Source/CDMarkdownTextLayoutManager.swift
@@ -17,10 +17,8 @@
         func textLayoutManager(_ textLayoutManager: NSTextLayoutManager,
                                textLayoutFragmentFor location: any NSTextLocation,
                                in textElement: NSTextElement) -> NSTextLayoutFragment {
-            let fragment = CDMarkdownTextLayoutFragment(textElement: textElement,
-                                                        range: textElement.elementRange)
-            fragment.roundAllCorners = roundAllCorners
-            return fragment
+            CDMarkdownTextLayoutFragment(textElement: textElement,
+                                         range: textElement.elementRange)
         }
     }
 #endif

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownTextLayoutManagerTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownTextLayoutManagerTests.swift
@@ -58,7 +58,7 @@ import Testing
         }
 
         @available(iOS 16.0, tvOS 16.0, *)
-        @Test func togglingRoundAllCornersAfterInitialLayoutDoesNotRetroactivelyUpdateAlreadyCreatedFragments() {
+        @Test func togglingRoundAllCornersAfterInitialLayoutRetroactivelyUpdatesAlreadyCreatedFragments() {
             let label = CDMarkdownLabel(frame: CGRect(x: 0, y: 0, width: 300, height: 200))
             label.configureTK2()
             let parser = CDMarkdownParser()
@@ -70,16 +70,10 @@ import Testing
             }
             layoutManager.ensureLayout(for: layoutManager.documentRange)
 
-            // KNOWN LIMITATION: flipping roundAllCorners after text is already laid out
-            // calls invalidateLayout(for:), but
-            // NSTextLayoutManager does not re-invoke the delegate's fragment factory for
-            // unchanged content -- it reuses the already-created NSTextLayoutFragment
-            // instances, and CDMarkdownTextLayoutFragment.roundAllCorners is a plain stored
-            // property set only once at creation time. Verified empirically against the real
-            // TextKit 2 API: creationCount does not increase after invalidateLayout + a second
-            // ensureLayout call. Set roundAllCorners before assigning attributedText to avoid
-            // this -- fragments created after the flag is set do pick it up correctly (see
-            // roundAllCornersPropagatesToNewlyCreatedFragments above).
+            // CDMarkdownTextLayoutFragment.roundAllCorners reads live from the delegate
+            // (mirroring the TK1 CDMarkdownLayoutManager approach) instead of caching a value
+            // snapshotted at fragment-creation time, so already-created fragments pick up a
+            // post-layout toggle without needing to be recreated.
             label.roundAllCorners = true
             layoutManager.ensureLayout(for: layoutManager.documentRange)
 
@@ -95,7 +89,7 @@ import Testing
                 return true
             }
             #expect(checkedAtLeastOneFragment)
-            #expect(sawRoundedFragment == false)
+            #expect(sawRoundedFragment == true)
         }
     }
 #endif


### PR DESCRIPTION
## Summary
- Fixes #68: toggling `CDMarkdownLabel`/`CDMarkdownTextView`'s `roundAllCorners` after `attributedText` was already laid out on TextKit 2 (iOS/tvOS 16+) didn't retroactively round already-displayed code/syntax backgrounds.
- Root cause: `CDMarkdownTextLayoutFragment.roundAllCorners` was a stored property snapshotted once when the fragment was created. `NSTextLayoutManager` reuses already-created fragment instances across `invalidateLayout(for:)` rather than recreating them, so the stale value never updated.
- Fix: `roundAllCorners` is now a computed property read live from the owning layout manager's delegate at draw time — mirroring how the TextKit 1 fallback (`CDMarkdownLayoutManager`) already reads its flag live at draw time.

## Test plan
- [x] Flipped the existing regression test (previously documenting the known limitation) to assert the fixed behavior; confirmed it failed against the pre-fix code, then passed after the fix.
- [x] Full UI-gated suite (244 tests) run against a real iPhone 17 Pro simulator via `xcodebuild test -scheme CDMarkdownKit-Package`.
- [x] `swift test` (215 tests, macOS host) passes.
- [x] `swiftformat --lint` and `swiftlint --strict` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qs4CYH2nupqGm8G5EHwQC