### PR TITLE
Fix table column width measured from escaped cell text, not rendered text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 - Fixed several test files failing to compile for visionOS, due to a platform check that predated visionOS support and was never updated to include it.
 - Fixed `CDMarkdownLabel` rendering garbled, overlapping text on iOS/tvOS 16+ whenever its content was taller than the label's own bounds, such as a fixed-height label without a scroll view. TextKit 2 fragments beyond what fit the container were drawn at the wrong position instead of being cleanly excluded.
 - Fixed `CDMarkdownLabel`/`CDMarkdownTextView`'s `roundAllCorners` flag not retroactively rounding already-displayed code and syntax backgrounds on TextKit 2 (iOS/tvOS 16+) when toggled after `attributedText` had already been laid out. The corner-rounding flag is now read live at draw time instead of being cached on each text layout fragment when it was created, matching the behavior already present on the TextKit 1 fallback.
+- Fixed Markdown tables measuring a column's width from its escaped, not rendered, cell text, so a column containing inline code was sized far too wide and threw off tab-stop alignment for any columns after it. Fixed alongside a related, more severe bug where inline code inside a table cell rendered as leftover escaped placeholder text instead of the original code.
 
 ---
 

--- a/Source/CDMarkdownParser.swift
+++ b/Source/CDMarkdownParser.swift
@@ -481,7 +481,6 @@ open class CDMarkdownParser {
                                                          .foregroundColor: fontColor as AnyObject]
         let result = NSMutableAttributedString(string: string, attributes: attrs)
         let inlineElements: [any CDMarkdownElement] = [
-            codeEscaping, escaping,
             link, automaticLink,
             bold, italic, strikethrough,
             code, unescaping

--- a/Source/CDMarkdownTable.swift
+++ b/Source/CDMarkdownTable.swift
@@ -118,15 +118,21 @@ open class CDMarkdownTable: CDMarkdownElement, CDMarkdownStyle {
         let columnCount = max(headerCells.count, dataRows.first?.count ?? 0)
         guard columnCount > 0 else { return }
 
-        // Measure the maximum rendered width of each column
+        /// Measure the maximum rendered width of each column. Cells are measured using the
+        /// post-unescape rendered text (not the raw, possibly UTF16-hex-escaped cell string)
+        /// so that a column containing e.g. inline code is sized to what's actually drawn.
+        func renderedText(for cell: String) -> String {
+            inlineParser?(cell).string ?? cell
+        }
+
         var columnWidths = [CGFloat](repeating: columnPadding, count: columnCount)
         for (columnIndex, cell) in headerCells.enumerated() where columnIndex < columnCount {
-            let columnWidth = cell.sizeWithAttributes(boldAttributes).width + columnPadding
+            let columnWidth = renderedText(for: cell).sizeWithAttributes(boldAttributes).width + columnPadding
             columnWidths[columnIndex] = max(columnWidths[columnIndex], columnWidth)
         }
         for row in dataRows {
             for (columnIndex, cell) in row.enumerated() where columnIndex < columnCount {
-                let columnWidth = cell.sizeWithAttributes(attributes).width + columnPadding
+                let columnWidth = renderedText(for: cell).sizeWithAttributes(attributes).width + columnPadding
                 columnWidths[columnIndex] = max(columnWidths[columnIndex], columnWidth)
             }
         }

--- a/Tests/CDMarkdownKitTests/Elements/CDMarkdownTableTests.swift
+++ b/Tests/CDMarkdownKitTests/Elements/CDMarkdownTableTests.swift
@@ -171,4 +171,45 @@ struct CDMarkdownTableTests {
         }
         #expect(foundCode)
     }
+
+    @Test func tableCellWithInlineCodeRendersOriginalText() async {
+        let input = """
+        | Header |
+        | ------ |
+        | `code` |
+        """
+        let result = await parser.parse(input)
+        #expect(result.string.contains("code"))
+        #expect(!result.string.contains("0063"))
+    }
+
+    @Test func tableNonFinalColumnWithInlineCodeMeasuresRenderedWidth() async {
+        let codeContent = "abcdefghijklmnopqrst"
+        let input = """
+        | A | Code | B |
+        | --- | ---- | --- |
+        | 1 | `\(codeContent)` | 2 |
+        """
+        let result = await parser.parse(input)
+
+        guard let tableStyle = result.attribute(.paragraphStyle,
+                                                at: 0,
+                                                effectiveRange: nil) as? NSParagraphStyle,
+            tableStyle.tabStops.count == 3 else {
+            #expect(Bool(false), "Expected a paragraph style with 3 tab stops")
+            return
+        }
+
+        // Column 0's measured width is unaffected by the bug (it contains no inline code),
+        // so it's a reliable baseline: tabStops[1].location == columnWidths[0].
+        let column0Width = tableStyle.tabStops[1].location
+        let actualColumn1Width = tableStyle.tabStops[2].location - column0Width
+
+        // The correct column width comes from the *rendered* (unescaped) cell text, not
+        // the UTF16-hex-escaped placeholder Phase 1 produces for the backtick span.
+        let expectedColumn1Width = codeContent.sizeWithAttributes(parser.table.attributes).width +
+            parser.table.columnPadding
+
+        #expect(abs(actualColumn1Width - expectedColumn1Width) < 1.0)
+    }
 }


### PR DESCRIPTION
## Summary
- `CDMarkdownTable` measured column widths from the raw, UTF16-hex-escaped cell string produced by Phase 1 escaping instead of the text actually drawn, so a column containing inline code (e.g. `` `| Cell | Cell |` ``) was measured ~4x too wide, throwing off tab-stop alignment for any later columns. Fixed by measuring from `inlineParser?(cell).string ?? cell` (the rendered/unescaped text) instead.
- Root-causing that also surfaced a more severe, related bug: `CDMarkdownParser`'s table-cell inline parser re-ran the escaping pass (`codeEscaping`/`escaping`) on cell text that had *already* been escaped once by the document-wide Phase 1 pass. The resulting double-escape only got undone once by the later unescape step, so inline code inside a table cell rendered as leftover hex digits (e.g. `0063006f00640065`) instead of the original text. Fixed by removing the redundant re-escaping from the table-cell inline-parsing pipeline.

Closes #72

## Test plan
- [x] Added `tableCellWithInlineCodeRendersOriginalText` — asserts inline code inside a table cell renders as its original text, not hex.
- [x] Added `tableNonFinalColumnWithInlineCodeMeasuresRenderedWidth` — asserts a non-final column containing inline code gets a correctly-sized tab stop (verified failing before the fix, off by ~478pt; passing after).
- [x] Full suite: `swift test` — 217/217 passing.
- [x] `swiftlint lint --strict` — 0 violations.
- [x] `swiftformat --lint` clean (formatting applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qs4CYH2nupqGm8G5EHwQC