### PR TITLE
Add test coverage for the macOS AppKit rendering stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@ All notable changes to this project will be documented in this file.
 - Fixed blank lines before a list item, when newline-collapsing is disabled, being miscounted as indentation and causing spurious list nesting.
 - Fixed a Markdown table silently dropping extra cells from a ragged row that was wider than its header or first row.
 - Fixed `CDMarkdownLabel`'s `attributedText` property not reflecting what was actually set when read back. As a result, `CDMarkdownLabel` now also correctly reports an intrinsic content size derived from its text, which was previously always absent — this may affect Auto Layout for existing consumers relying on the old always-zero-ish sizing behavior.
-- Fixed `CDMarkdownNSTextView` never actually adopting its own rounded-corner-drawing layout manager and text storage. Creating one programmatically could crash during initialization; code span backgrounds never rendered; and using the view from a storyboard or XIB could leave any text that was set on it invisible, since it was written into a text storage the view never displayed.
-- Fixed `CDMarkdownNSLabel` not redrawing when its `roundAllCorners` property was toggled after the label had already been displayed, leaving rounded corners visually stale until some unrelated state change happened to force a redraw.
+- Fixed `CDMarkdownNSTextView` never actually adopting its own rounded-corner-drawing layout manager and text storage. Creating one programmatically crashed during initialization; code span backgrounds never rendered; and using the view from a storyboard or XIB could leave any text that was set on it invisible, since it was written into a text storage the view never displayed.
+- Fixed `CDMarkdownNSLabel` and `CDMarkdownNSTextView` not redrawing when their `roundAllCorners` property was toggled after the view had already been displayed, leaving rounded corners visually stale until some unrelated state change happened to force a redraw.
+- Fixed `CDMarkdownNSTextView` never wrapping its text when created programmatically. Its text container was given no width, so every line ran off the right edge instead of wrapping, and resizing the view never re-wrapped the content.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ All notable changes to this project will be documented in this file.
 - Fixed blank lines before a list item, when newline-collapsing is disabled, being miscounted as indentation and causing spurious list nesting.
 - Fixed a Markdown table silently dropping extra cells from a ragged row that was wider than its header or first row.
 - Fixed `CDMarkdownLabel`'s `attributedText` property not reflecting what was actually set when read back. As a result, `CDMarkdownLabel` now also correctly reports an intrinsic content size derived from its text, which was previously always absent — this may affect Auto Layout for existing consumers relying on the old always-zero-ish sizing behavior.
+- Fixed `CDMarkdownNSTextView` never actually adopting its own rounded-corner-drawing layout manager and text storage. Code span backgrounds never rendered, and using the view from a storyboard or XIB could leave any text that was set on it invisible, since it was written into a text storage the view never displayed.
+- Fixed `CDMarkdownNSLabel` not redrawing when its `roundAllCorners` property was toggled after the label had already been displayed, leaving rounded corners visually stale until some unrelated state change happened to force a redraw.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ All notable changes to this project will be documented in this file.
 - Fixed blank lines before a list item, when newline-collapsing is disabled, being miscounted as indentation and causing spurious list nesting.
 - Fixed a Markdown table silently dropping extra cells from a ragged row that was wider than its header or first row.
 - Fixed `CDMarkdownLabel`'s `attributedText` property not reflecting what was actually set when read back. As a result, `CDMarkdownLabel` now also correctly reports an intrinsic content size derived from its text, which was previously always absent — this may affect Auto Layout for existing consumers relying on the old always-zero-ish sizing behavior.
-- Fixed `CDMarkdownNSTextView` never actually adopting its own rounded-corner-drawing layout manager and text storage. Code span backgrounds never rendered, and using the view from a storyboard or XIB could leave any text that was set on it invisible, since it was written into a text storage the view never displayed.
+- Fixed `CDMarkdownNSTextView` never actually adopting its own rounded-corner-drawing layout manager and text storage. Creating one programmatically could crash during initialization; code span backgrounds never rendered; and using the view from a storyboard or XIB could leave any text that was set on it invisible, since it was written into a text storage the view never displayed.
 - Fixed `CDMarkdownNSLabel` not redrawing when its `roundAllCorners` property was toggled after the label had already been displayed, leaving rounded corners visually stale until some unrelated state change happened to force a redraw.
 
 ---

--- a/Source/CDMarkdownNSLabel.swift
+++ b/Source/CDMarkdownNSLabel.swift
@@ -26,6 +26,7 @@
         open var roundAllCorners: Bool = false {
             didSet {
                 layoutManager.roundAllCorners = roundAllCorners
+                needsDisplay = true
             }
         }
 

--- a/Source/CDMarkdownNSTextView.swift
+++ b/Source/CDMarkdownNSTextView.swift
@@ -28,12 +28,30 @@
         // MARK: - Initializers
 
         override public init(frame: NSRect) {
-            super.init(frame: frame, textContainer: nil)
+            let container = NSTextContainer()
+            let layoutManager = CDMarkdownNSLayoutManager()
+            let textStorage = NSTextStorage()
+            textStorage.addLayoutManager(layoutManager)
+            layoutManager.addTextContainer(container)
+
+            super.init(frame: frame, textContainer: container)
+
+            customLayoutManager = layoutManager
+            customTextStorage = textStorage
             configure()
         }
 
         public required init?(coder: NSCoder) {
             super.init(coder: coder)
+
+            let container = NSTextContainer()
+            let layoutManager = CDMarkdownNSLayoutManager()
+            let textStorage = NSTextStorage()
+            textStorage.addLayoutManager(layoutManager)
+            layoutManager.addTextContainer(container)
+
+            customLayoutManager = layoutManager
+            customTextStorage = textStorage
             configure()
         }
 
@@ -44,16 +62,6 @@
         /// Called automatically during initialization. This method sets up the ``CDMarkdownNSLayoutManager``
         /// and `NSTextStorage` for rendering with rounded-corner backgrounds.
         open func configure() {
-            // Replace the default layout manager with our custom one
-            if let defaultLM = layoutManager {
-                textStorage?.removeLayoutManager(defaultLM)
-            }
-
-            customLayoutManager = CDMarkdownNSLayoutManager()
-            customTextStorage = NSTextStorage()
-            customTextStorage.addLayoutManager(customLayoutManager)
-            customLayoutManager.addTextContainer(textContainer!)
-
             isEditable = false
             isSelectable = true // required for link clicks on macOS
         }

--- a/Source/CDMarkdownNSTextView.swift
+++ b/Source/CDMarkdownNSTextView.swift
@@ -29,8 +29,7 @@
 
         override public init(frame: NSRect) {
             let container = NSTextContainer()
-            let layoutManager = CDMarkdownNSLayoutManager()
-            let textStorage = NSTextStorage()
+            let (layoutManager, textStorage) = Self.makeLayoutManagerAndTextStorage()
             textStorage.addLayoutManager(layoutManager)
             layoutManager.addTextContainer(container)
 
@@ -44,23 +43,36 @@
         public required init?(coder: NSCoder) {
             super.init(coder: coder)
 
-            let container = NSTextContainer()
-            let layoutManager = CDMarkdownNSLayoutManager()
-            let textStorage = NSTextStorage()
+            // `super.init(coder:)` has already created and attached AppKit's own default
+            // text container/layout manager/text storage to `self`. Unlike `init(frame:)`,
+            // there's no way to hand a pre-wired container into `super.init(coder:)`, so
+            // instead we reuse the text container AppKit already created and swap in our
+            // own layout manager as its active layout manager. `replaceLayoutManager(_:)`
+            // pulls the *old* layout manager's text storage association onto the new one,
+            // so `addLayoutManager(_:)` must run afterward to make our own text storage
+            // the active one instead.
+            let (layoutManager, textStorage) = Self.makeLayoutManagerAndTextStorage()
+            textContainer?.replaceLayoutManager(layoutManager)
             textStorage.addLayoutManager(layoutManager)
-            layoutManager.addTextContainer(container)
 
             customLayoutManager = layoutManager
             customTextStorage = textStorage
             configure()
         }
 
+        /// Constructs a fresh, not-yet-wired ``CDMarkdownNSLayoutManager``/`NSTextStorage`
+        /// pair for use by either initializer; each initializer wires them into the text
+        /// system in the order its own initialization path requires.
+        private static func makeLayoutManagerAndTextStorage() -> (CDMarkdownNSLayoutManager, NSTextStorage) {
+            (CDMarkdownNSLayoutManager(), NSTextStorage())
+        }
+
         // MARK: - Configuration
 
-        /// Configures the text view's custom layout manager and text storage.
+        /// Configures the text view for read-only Markdown display.
         ///
-        /// Called automatically during initialization. This method sets up the ``CDMarkdownNSLayoutManager``
-        /// and `NSTextStorage` for rendering with rounded-corner backgrounds.
+        /// Called automatically during initialization, after the custom text system
+        /// (``customLayoutManager``/``customTextStorage``) has already been wired up.
         open func configure() {
             isEditable = false
             isSelectable = true // required for link clicks on macOS

--- a/Source/CDMarkdownNSTextView.swift
+++ b/Source/CDMarkdownNSTextView.swift
@@ -22,13 +22,19 @@
         open var roundAllCorners: Bool = false {
             didSet {
                 customLayoutManager?.roundAllCorners = roundAllCorners
+                needsDisplay = true
             }
         }
 
         // MARK: - Initializers
 
         override public init(frame: NSRect) {
-            let container = NSTextContainer()
+            // A manually constructed `NSTextContainer` has no size and does not track its
+            // text view's width, which makes AppKit stretch it to its 10,000,000pt maximum.
+            // Text would then never wrap, and resizing the view would never re-wrap it.
+            let container = NSTextContainer(size: NSSize(width: frame.width,
+                                                         height: .greatestFiniteMagnitude))
+            container.widthTracksTextView = true
             let (layoutManager, textStorage) = Self.makeLayoutManagerAndTextStorage()
             textStorage.addLayoutManager(layoutManager)
             layoutManager.addTextContainer(container)

--- a/Tests/CDMarkdownKitTests/Extensions/CDMarkdownNSMutableAttributedStringExtensionTests.swift
+++ b/Tests/CDMarkdownKitTests/Extensions/CDMarkdownNSMutableAttributedStringExtensionTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
+    import UIKit
+#elseif os(macOS)
+    import Cocoa
+#endif
+@testable import CDMarkdownKit
+
+@MainActor
+struct CDMarkdownNSMutableAttributedStringExtensionTests {
+
+    @Test func removeBackgroundColorRemovesOnlyBackgroundColorAttribute() {
+        let attributedString = NSMutableAttributedString(string: "code span")
+        let range = NSRange(location: 0, length: attributedString.length)
+        attributedString.addBackgroundColor(CDColor.red, toRange: range)
+        attributedString.addForegroundColor(CDColor.blue, toRange: range)
+
+        attributedString.removeBackgroundColor(atRange: range)
+
+        let backgroundColor = attributedString.attribute(.backgroundColor, at: 0, effectiveRange: nil)
+        #expect(backgroundColor == nil)
+
+        let foregroundColor = attributedString.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? CDColor
+        #expect(foregroundColor == CDColor.blue)
+    }
+
+    @Test func removeBackgroundColorOnPartialRangeLeavesRestIntact() {
+        let attributedString = NSMutableAttributedString(string: "aaaa bbbb")
+        let fullRange = NSRange(location: 0, length: attributedString.length)
+        attributedString.addBackgroundColor(CDColor.red, toRange: fullRange)
+
+        let partialRange = NSRange(location: 0, length: 4)
+        attributedString.removeBackgroundColor(atRange: partialRange)
+
+        let removedColor = attributedString.attribute(.backgroundColor, at: 0, effectiveRange: nil)
+        #expect(removedColor == nil)
+
+        let remainingColor = attributedString.attribute(.backgroundColor, at: 5, effectiveRange: nil) as? CDColor
+        #expect(remainingColor == CDColor.red)
+    }
+}

--- a/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownTextTests.swift
+++ b/Tests/CDMarkdownKitTests/SwiftUI/CDMarkdownTextTests.swift
@@ -67,4 +67,30 @@ struct CDMarkdownTextTests {
         let view = CDMarkdownText("test").markdownParser(customParser)
         #expect(type(of: view) != CDMarkdownText.self) // wrapped in modifier
     }
+
+    #if !os(watchOS)
+        @available(iOS 16.0, tvOS 16.0, macOS 13.0, visionOS 1.0, *)
+        @Test func markdownThemeModifierPropagatesThroughLiveViewHierarchy() {
+            final class ThemeBox {
+                var captured: CDMarkdownTheme?
+            }
+            struct ThemeCapturingView: View {
+                @Environment(\.markdownTheme) var theme
+                let box: ThemeBox
+                var body: some View {
+                    box.captured = theme
+                    return Color.clear.frame(width: 1, height: 1)
+                }
+            }
+
+            var theme = CDMarkdownTheme.default
+            theme.fontColor = .red
+            let box = ThemeBox()
+
+            let renderer = ImageRenderer(content: ThemeCapturingView(box: box).markdownTheme(theme))
+            _ = renderer.cgImage
+
+            #expect(box.captured?.fontColor == theme.fontColor)
+        }
+    #endif
 }

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLabelTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLabelTests.swift
@@ -27,9 +27,9 @@
             #expect(label.roundAllCorners == true)
         }
 
-        @Test func labelDrawWithCodeSpanDoesNotCrash() {
+        @Test func labelDrawWithCodeSpanDoesNotCrash() async {
             let label = CDMarkdownNSLabel(frame: NSRect(x: 0, y: 0, width: 200, height: 60))
-            label.attributedText = parser.parse("`code span`")
+            label.attributedText = await parser.parse("`code span`")
             label.layout()
 
             guard let rep = label.bitmapImageRepForCachingDisplay(in: label.bounds) else {
@@ -41,11 +41,16 @@
             #expect(rep.tiffRepresentation != nil)
         }
 
-        @Test func labelRoundAllCornersChangesRenderedPixelsForCodeSpan() {
+        @Test func labelRoundAllCornersChangesRenderedPixelsForBackgroundColoredText() {
             func renderedTIFF(roundAllCorners: Bool) -> Data? {
+                let attributedString = NSMutableAttributedString(string: "background text")
+                attributedString.addAttribute(.backgroundColor,
+                                              value: CDColor.red,
+                                              range: NSRange(location: 0, length: attributedString.length))
+
                 let label = CDMarkdownNSLabel(frame: NSRect(x: 0, y: 0, width: 200, height: 60))
                 label.roundAllCorners = roundAllCorners
-                label.attributedText = parser.parse("`code span`")
+                label.attributedText = attributedString
                 label.layout()
                 guard let rep = label.bitmapImageRepForCachingDisplay(in: label.bounds) else { return nil }
                 label.cacheDisplay(in: label.bounds, to: rep)

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLabelTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLabelTests.swift
@@ -26,6 +26,39 @@
             label.roundAllCorners = true
             #expect(label.roundAllCorners == true)
         }
+
+        @Test func labelDrawWithCodeSpanDoesNotCrash() {
+            let label = CDMarkdownNSLabel(frame: NSRect(x: 0, y: 0, width: 200, height: 60))
+            label.attributedText = parser.parse("`code span`")
+            label.layout()
+
+            guard let rep = label.bitmapImageRepForCachingDisplay(in: label.bounds) else {
+                Issue.record("expected a bitmap image rep for caching display")
+                return
+            }
+            label.cacheDisplay(in: label.bounds, to: rep)
+
+            #expect(rep.tiffRepresentation != nil)
+        }
+
+        @Test func labelRoundAllCornersChangesRenderedPixelsForCodeSpan() {
+            func renderedTIFF(roundAllCorners: Bool) -> Data? {
+                let label = CDMarkdownNSLabel(frame: NSRect(x: 0, y: 0, width: 200, height: 60))
+                label.roundAllCorners = roundAllCorners
+                label.attributedText = parser.parse("`code span`")
+                label.layout()
+                guard let rep = label.bitmapImageRepForCachingDisplay(in: label.bounds) else { return nil }
+                label.cacheDisplay(in: label.bounds, to: rep)
+                return rep.tiffRepresentation
+            }
+
+            let square = renderedTIFF(roundAllCorners: false)
+            let rounded = renderedTIFF(roundAllCorners: true)
+
+            #expect(square != nil)
+            #expect(rounded != nil)
+            #expect(square != rounded)
+        }
     }
 
 #endif

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLayoutManagerTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLayoutManagerTests.swift
@@ -78,40 +78,35 @@
             image.unlockFocus()
         }
 
-        @Test func fillBackgroundRectArrayHonorsRoundAllCornersWhenAttributeAbsent() {
-            let layoutManager = CDMarkdownNSLayoutManager()
-            layoutManager.roundAllCorners = true
-            let textStorage = NSTextStorage(string: "plain text, no code attribute")
-            textStorage.addLayoutManager(layoutManager)
+        @Test func fillBackgroundRectArrayRoundAllCornersProducesDifferentPixelsThanSquareFallback() {
+            func renderedTIFF(roundAllCorners: Bool) -> Data? {
+                let layoutManager = CDMarkdownNSLayoutManager()
+                layoutManager.roundAllCorners = roundAllCorners
+                let textStorage = NSTextStorage(string: "plain text, no code attribute")
+                textStorage.addLayoutManager(layoutManager)
 
-            let image = NSImage(size: NSSize(width: 100, height: 40))
-            image.lockFocus()
-            let rects = [NSRect(x: 0, y: 0, width: 80, height: 20)]
-            rects.withUnsafeBufferPointer { buffer in
-                layoutManager.fillBackgroundRectArray(buffer.baseAddress!,
-                                                      count: buffer.count,
-                                                      forCharacterRange: NSRange(location: 0, length: 5),
-                                                      color: .blue)
+                let image = NSImage(size: NSSize(width: 100, height: 40))
+                image.lockFocus()
+                let rects = [NSRect(x: 0, y: 0, width: 80, height: 20)]
+                rects.withUnsafeBufferPointer { buffer in
+                    layoutManager.fillBackgroundRectArray(buffer.baseAddress!,
+                                                          count: buffer.count,
+                                                          forCharacterRange: NSRange(location: 0, length: 5),
+                                                          color: .blue)
+                }
+                // Must be captured while focus is still locked -- `NSBitmapImageRep(focusedViewRect:)`
+                // reads back the currently focused drawing destination.
+                let rep = NSBitmapImageRep(focusedViewRect: NSRect(x: 0, y: 0, width: 100, height: 40))
+                image.unlockFocus()
+                return rep?.tiffRepresentation
             }
-            image.unlockFocus()
-        }
 
-        @Test func fillBackgroundRectArrayFallsBackToSuperWhenNeitherRoundAllCornersNorAttributeSet() {
-            let layoutManager = CDMarkdownNSLayoutManager()
-            let textStorage = NSTextStorage(string: "plain text")
-            textStorage.addLayoutManager(layoutManager)
+            let square = renderedTIFF(roundAllCorners: false)
+            let rounded = renderedTIFF(roundAllCorners: true)
 
-            let image = NSImage(size: NSSize(width: 100, height: 40))
-            image.lockFocus()
-            let rects = [NSRect(x: 0, y: 0, width: 80, height: 20)]
-            rects.withUnsafeBufferPointer { buffer in
-                layoutManager.fillBackgroundRectArray(buffer.baseAddress!,
-                                                      count: buffer.count,
-                                                      forCharacterRange: NSRange(location: 0, length: 5),
-                                                      color: .green)
-            }
-            image.unlockFocus()
-            #expect(layoutManager.roundAllCorners == false)
+            #expect(square != nil)
+            #expect(rounded != nil)
+            #expect(square != rounded)
         }
 
         @Test func hasRoundedAttributeReturnsFalseWhenRangeAtTextStorageLength() {

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLayoutManagerTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLayoutManagerTests.swift
@@ -39,8 +39,8 @@
 
             let image = NSImage(size: NSSize(width: 100, height: 60))
             image.lockFocus()
-            // Two rects with a gap (rects[1].maxX < rects[0].minX) -- exercises the
-            // "2 rects without edges in contact" branch.
+            // Two rects with a gap (rects[1].maxX < rects[0].minX) -- macOS draws every rect through
+            // the same uniform loop regardless of count; this exercises it with two disjoint rects.
             let rects = [
                 NSRect(x: 60, y: 0, width: 40, height: 20),
                 NSRect(x: 0, y: 20, width: 20, height: 20)
@@ -62,7 +62,8 @@
 
             let image = NSImage(size: NSSize(width: 100, height: 60))
             image.lockFocus()
-            // Three rects spanning wrapped lines -- exercises the hand-rolled multi-rect path.
+            // Three rects spanning wrapped lines -- macOS draws every rect through
+            // the same uniform loop regardless of count; this exercises it with three rects.
             let rects = [
                 NSRect(x: 40, y: 0, width: 40, height: 20),
                 NSRect(x: 0, y: 20, width: 100, height: 20),

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLayoutManagerTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownNSLayoutManagerTests.swift
@@ -1,0 +1,136 @@
+#if os(macOS)
+
+    import Cocoa
+    import Testing
+    @testable import CDMarkdownKit
+
+    @MainActor
+    struct CDMarkdownNSLayoutManagerTests {
+
+        @Test func roundAllCornersDefaultsFalse() {
+            let layoutManager = CDMarkdownNSLayoutManager()
+            #expect(layoutManager.roundAllCorners == false)
+        }
+
+        @Test func fillBackgroundRectArraySingleRectDoesNotCrash() {
+            let layoutManager = CDMarkdownNSLayoutManager()
+            let textStorage = NSTextStorage(string: "code")
+            textStorage.addAttribute(.cdMarkdownRoundedBackground, value: true, range: NSRange(location: 0, length: 4))
+            textStorage.addLayoutManager(layoutManager)
+
+            let image = NSImage(size: NSSize(width: 100, height: 40))
+            image.lockFocus()
+            let rects = [NSRect(x: 0, y: 0, width: 80, height: 20)]
+            rects.withUnsafeBufferPointer { buffer in
+                layoutManager.fillBackgroundRectArray(buffer.baseAddress!,
+                                                      count: buffer.count,
+                                                      forCharacterRange: NSRange(location: 0, length: 4),
+                                                      color: .red)
+            }
+            image.unlockFocus()
+            #expect(layoutManager.textStorage === textStorage)
+        }
+
+        @Test func fillBackgroundRectArrayTwoDisjointRectsDoesNotCrash() {
+            let layoutManager = CDMarkdownNSLayoutManager()
+            let textStorage = NSTextStorage(string: "wrapped code")
+            textStorage.addAttribute(.cdMarkdownRoundedBackground, value: true, range: NSRange(location: 0, length: 12))
+            textStorage.addLayoutManager(layoutManager)
+
+            let image = NSImage(size: NSSize(width: 100, height: 60))
+            image.lockFocus()
+            // Two rects with a gap (rects[1].maxX < rects[0].minX) -- exercises the
+            // "2 rects without edges in contact" branch.
+            let rects = [
+                NSRect(x: 60, y: 0, width: 40, height: 20),
+                NSRect(x: 0, y: 20, width: 20, height: 20)
+            ]
+            rects.withUnsafeBufferPointer { buffer in
+                layoutManager.fillBackgroundRectArray(buffer.baseAddress!,
+                                                      count: buffer.count,
+                                                      forCharacterRange: NSRange(location: 0, length: 12),
+                                                      color: .red)
+            }
+            image.unlockFocus()
+        }
+
+        @Test func fillBackgroundRectArrayThreeWrappedRectsDoesNotCrash() {
+            let layoutManager = CDMarkdownNSLayoutManager()
+            let textStorage = NSTextStorage(string: "a longer wrapped code span")
+            textStorage.addAttribute(.cdMarkdownRoundedBackground, value: true, range: NSRange(location: 0, length: 26))
+            textStorage.addLayoutManager(layoutManager)
+
+            let image = NSImage(size: NSSize(width: 100, height: 60))
+            image.lockFocus()
+            // Three rects spanning wrapped lines -- exercises the hand-rolled multi-rect path.
+            let rects = [
+                NSRect(x: 40, y: 0, width: 40, height: 20),
+                NSRect(x: 0, y: 20, width: 100, height: 20),
+                NSRect(x: 0, y: 40, width: 30, height: 20)
+            ]
+            rects.withUnsafeBufferPointer { buffer in
+                layoutManager.fillBackgroundRectArray(buffer.baseAddress!,
+                                                      count: buffer.count,
+                                                      forCharacterRange: NSRange(location: 0, length: 26),
+                                                      color: .red)
+            }
+            image.unlockFocus()
+        }
+
+        @Test func fillBackgroundRectArrayHonorsRoundAllCornersWhenAttributeAbsent() {
+            let layoutManager = CDMarkdownNSLayoutManager()
+            layoutManager.roundAllCorners = true
+            let textStorage = NSTextStorage(string: "plain text, no code attribute")
+            textStorage.addLayoutManager(layoutManager)
+
+            let image = NSImage(size: NSSize(width: 100, height: 40))
+            image.lockFocus()
+            let rects = [NSRect(x: 0, y: 0, width: 80, height: 20)]
+            rects.withUnsafeBufferPointer { buffer in
+                layoutManager.fillBackgroundRectArray(buffer.baseAddress!,
+                                                      count: buffer.count,
+                                                      forCharacterRange: NSRange(location: 0, length: 5),
+                                                      color: .blue)
+            }
+            image.unlockFocus()
+        }
+
+        @Test func fillBackgroundRectArrayFallsBackToSuperWhenNeitherRoundAllCornersNorAttributeSet() {
+            let layoutManager = CDMarkdownNSLayoutManager()
+            let textStorage = NSTextStorage(string: "plain text")
+            textStorage.addLayoutManager(layoutManager)
+
+            let image = NSImage(size: NSSize(width: 100, height: 40))
+            image.lockFocus()
+            let rects = [NSRect(x: 0, y: 0, width: 80, height: 20)]
+            rects.withUnsafeBufferPointer { buffer in
+                layoutManager.fillBackgroundRectArray(buffer.baseAddress!,
+                                                      count: buffer.count,
+                                                      forCharacterRange: NSRange(location: 0, length: 5),
+                                                      color: .green)
+            }
+            image.unlockFocus()
+            #expect(layoutManager.roundAllCorners == false)
+        }
+
+        @Test func hasRoundedAttributeReturnsFalseWhenRangeAtTextStorageLength() {
+            let layoutManager = CDMarkdownNSLayoutManager()
+            let textStorage = NSTextStorage(string: "abc")
+            textStorage.addLayoutManager(layoutManager)
+
+            let image = NSImage(size: NSSize(width: 100, height: 40))
+            image.lockFocus()
+            // charRange.location (3) == textStorage.length (3) -- the boundary
+            // hasRoundedAttribute(at:) guards against with `charRange.location < textStorage.length`.
+            let rects = [NSRect(x: 0, y: 0, width: 80, height: 20)]
+            rects.withUnsafeBufferPointer { buffer in
+                layoutManager.fillBackgroundRectArray(buffer.baseAddress!,
+                                                      count: buffer.count,
+                                                      forCharacterRange: NSRange(location: 3, length: 0),
+                                                      color: .red)
+            }
+            image.unlockFocus()
+        }
+    }
+
+#endif

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownNSTextViewTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownNSTextViewTests.swift
@@ -1,0 +1,53 @@
+#if os(macOS)
+
+    import Cocoa
+    import Testing
+    @testable import CDMarkdownKit
+
+    @MainActor
+    struct CDMarkdownNSTextViewTests {
+
+        let parser = CDMarkdownParser()
+
+        @Test func configureWiresCustomLayoutManagerAsTextViewsActiveLayoutManager() {
+            let textView = CDMarkdownNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+            #expect(textView.customLayoutManager != nil)
+            #expect(textView.layoutManager === textView.customLayoutManager)
+        }
+
+        @Test func configureWiresCustomTextStorageAsTextViewsActiveTextStorage() {
+            let textView = CDMarkdownNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+            #expect(textView.customTextStorage != nil)
+            #expect(textView.textStorage === textView.customTextStorage)
+        }
+
+        @Test func configureMakesTextViewReadOnlyButSelectable() {
+            let textView = CDMarkdownNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+            #expect(textView.isEditable == false)
+            #expect(textView.isSelectable == true)
+        }
+
+        @Test func setAttributedStringUpdatesCustomTextStorage() {
+            let textView = CDMarkdownNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+            let attributed = parser.parse("Hello **world**")
+
+            textView.setAttributedString(attributed)
+
+            #expect(textView.customTextStorage.string == attributed.string)
+            #expect(textView.textStorage?.string == attributed.string)
+        }
+
+        @Test func roundAllCornersPropagatesToCustomLayoutManager() {
+            let textView = CDMarkdownNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+            textView.roundAllCorners = true
+            #expect(textView.customLayoutManager.roundAllCorners == true)
+        }
+
+        @Test func roundAllCornersDefaultsFalse() {
+            let textView = CDMarkdownNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+            #expect(textView.roundAllCorners == false)
+            #expect(textView.customLayoutManager.roundAllCorners == false)
+        }
+    }
+
+#endif

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownNSTextViewTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownNSTextViewTests.swift
@@ -27,9 +27,15 @@
             #expect(textView.isSelectable == true)
         }
 
-        @Test func setAttributedStringUpdatesCustomTextStorage() {
+        @Test func configureGivesTextContainerAFiniteWidthThatTracksTheView() {
             let textView = CDMarkdownNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
-            let attributed = parser.parse("Hello **world**")
+            #expect(textView.textContainer?.widthTracksTextView == true)
+            #expect(textView.textContainer?.containerSize.width == 300)
+        }
+
+        @Test func setAttributedStringUpdatesCustomTextStorage() async {
+            let textView = CDMarkdownNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+            let attributed = await parser.parse("Hello **world**")
 
             textView.setAttributedString(attributed)
 

--- a/Tests/CDMarkdownKitTests/UI/CDMarkdownNSTextViewTests.swift
+++ b/Tests/CDMarkdownKitTests/UI/CDMarkdownNSTextViewTests.swift
@@ -48,6 +48,25 @@
             #expect(textView.roundAllCorners == false)
             #expect(textView.customLayoutManager.roundAllCorners == false)
         }
+
+        @Test func initWithCoderWiresCustomLayoutManagerAndTextStorageAsTextViewsActiveTextSystem() throws {
+            let original = CDMarkdownNSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 100))
+            let data = try NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: false)
+
+            let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+            unarchiver.requiresSecureCoding = false
+            let decoded = unarchiver.decodeObject(
+                of: CDMarkdownNSTextView.self,
+                forKey: NSKeyedArchiveRootObjectKey
+            )
+            unarchiver.finishDecoding()
+            let textView = try #require(decoded)
+
+            #expect(textView.customLayoutManager != nil)
+            #expect(textView.customTextStorage != nil)
+            #expect(textView.layoutManager === textView.customLayoutManager)
+            #expect(textView.textStorage === textView.customTextStorage)
+        }
     }
 
 #endif


### PR DESCRIPTION
## Summary

Closes #83. Adds test coverage for CDMarkdownKit's macOS AppKit rendering stack (`CDMarkdownNSTextView`, `CDMarkdownNSLayoutManager`, `CDMarkdownNSLabel`), plus two related coverage gaps: `.markdownTheme(_:)` SwiftUI environment propagation through a live view hierarchy, and an isolated unit test for `NSMutableAttributedString.removeBackgroundColor`.

Writing these tests surfaced three real, previously-invisible production bugs, all fixed here:

- `CDMarkdownNSTextView`'s `configure()` never actually made its custom rounded-corner-drawing layout manager and text storage the view's active ones. Creating one programmatically crashed unconditionally (force-unwrapping a nil text container); creating one from a storyboard/XIB left the custom objects orphaned, so any text set via `setAttributedString(_:)` was written into a text storage the view never displayed.
- The same `init(frame:)` path also produced a text container with no width tracking, so once the crash was fixed, documents still rendered as unwrapped content running off the edge of the view instead of wrapping to its width.
- `CDMarkdownNSLabel` and `CDMarkdownNSTextView` both failed to redraw when their `roundAllCorners` property was toggled after the view had already been displayed.

## Test plan

- [x] `swift test` — 251/251 tests passing, 36 suites
- [x] `swiftformat Source Tests --lint` — clean
- [x] `swiftlint --strict` — 0 violations
- [x] New pixel-comparison tests (`CDMarkdownNSLabelTests`, `CDMarkdownNSLayoutManagerTests`) verified to genuinely produce different rendered output between `roundAllCorners` states, not just non-crashing calls
- [x] New `CDMarkdownNSTextViewTests` regression test confirms the text-wrapping fix (`widthTracksTextView == true`, finite `containerSize.width`)
- [x] New coder-path test constructs `CDMarkdownNSTextView` via a real `NSKeyedArchiver`/`NSKeyedUnarchiver` round-trip to confirm the storyboard/XIB initialization path is fixed too

🤖 Generated with [Claude Code](https://claude.com/claude-code)