### PR TITLE
Core-parsing cleanup: dead code, doc-order drift, and a latent parse-loop hazard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file.
 - Fixed `CDMarkdownNSTextView` never actually adopting its own rounded-corner-drawing layout manager and text storage. Creating one programmatically crashed during initialization; code span backgrounds never rendered; and using the view from a storyboard or XIB could leave any text that was set on it invisible, since it was written into a text storage the view never displayed.
 - Fixed `CDMarkdownNSLabel` and `CDMarkdownNSTextView` not redrawing when their `roundAllCorners` property was toggled after the view had already been displayed, leaving rounded corners visually stale until some unrelated state change happened to force a redraw.
 - Fixed `CDMarkdownNSTextView` never wrapping its text when created programmatically. Its text container was given no width, so every line ran off the right edge instead of wrapping, and resizing the view never re-wrapped the content.
+- Hardened the default `CDMarkdownElement.parse()` loop so a custom element whose regular expression can produce a zero-length match can no longer cause parsing to loop indefinitely.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,13 @@ See `Documentation/ARCHITECTURE.md` for the full diagram. Summary:
 ```
 Input String
     ↓
-[Phase 1 — Escaping]
-    CDMarkdownCodeEscaping   — UTF16-hex-encodes content inside backtick spans
-    CDMarkdownEscaping       — UTF16-hex-encodes \-escaped characters
+[Phase 1 — Reference Definition Extraction]
+    CDMarkdownLinkReference  — strips [ref]: url lines; populates references dict
 
     ↓
-[Phase 1.5 — Reference Definition Extraction]
-    CDMarkdownLinkReference  — strips [ref]: url lines; populates references dict
+[Phase 1.5 — Escaping]
+    CDMarkdownCodeEscaping   — UTF16-hex-encodes content inside backtick spans
+    CDMarkdownEscaping       — UTF16-hex-encodes \-escaped characters
 
     ↓
 [Phase 2 — Element Parsing]  (order matters; earlier elements take priority)
@@ -98,7 +98,9 @@ Input String
     resolveImages(in:)       — downloads remote images via URLSession, injects NSTextAttachment
 ```
 
-**Why escaping first?** Code spans must not be parsed for inner markdown. The escaping phase converts their contents to hex sequences that no other element regex can match, then Phase 3 reverses this.
+**Why reference extraction first?** Reference definition titles can contain literal `"`, `'`, `(`, or `)` characters (e.g. `[ref]: url "a title"`) that the extraction regex matches literally. Running escaping first would UTF16-hex-encode any backslash-escaped punctuation inside those titles before the regex ever saw it, silently breaking extraction for definitions with escaped title punctuation — so reference extraction runs against the raw string first.
+
+**Why escaping before element parsing?** Code spans must not be parsed for inner markdown. The escaping phase converts their contents to hex sequences that no other element regex can match, then Phase 3 reverses this.
 
 ---
 
@@ -126,8 +128,8 @@ CDMarkdownElement          (parse loop + regex matching)
 └── Direct CDMarkdownElement implementations
     ├── CDMarkdownTable          (pipe-delimited GFM tables)
     ├── CDMarkdownHorizontalRule (---, ***, ___ rules)
-    ├── CDMarkdownCodeEscaping   (Phase 1 UTF16-hex encoding)
-    ├── CDMarkdownEscaping       (Phase 1 backslash encoding)
+    ├── CDMarkdownCodeEscaping   (Phase 1.5 UTF16-hex encoding)
+    ├── CDMarkdownEscaping       (Phase 1.5 backslash encoding)
     └── CDMarkdownUnescaping     (Phase 3 decode)
 ```
 

--- a/Documentation/ARCHITECTURE.md
+++ b/Documentation/ARCHITECTURE.md
@@ -18,7 +18,20 @@ Input: String or NSAttributedString
 │
 ▼
 ┌─────────────────────────────────────────────────────────────┐
-│  Phase 1 — ESCAPING                                         │
+│  Phase 1 — REFERENCE DEFINITION EXTRACTION                 │
+│                                                             │
+│  CDMarkdownLinkReference                                    │
+│    Strips [ref]: url lines from the string and populates    │
+│    CDMarkdownLinkReference.references with the mappings,   │
+│    so Phase 2 link reference parsing can resolve them.      │
+│    Runs against the raw string, before escaping, so         │
+│    literal title punctuation (e.g. \" inside a quoted        │
+│    title) hasn't been UTF16-hex-encoded yet.                │
+└─────────────────────────────────────────────────────────────┘
+│
+▼
+┌─────────────────────────────────────────────────────────────┐
+│  Phase 1.5 — ESCAPING                                       │
 │                                                             │
 │  CDMarkdownCodeEscaping                                     │
 │    Converts content inside backtick spans to UTF16-hex      │
@@ -28,16 +41,6 @@ Input: String or NSAttributedString
 │  CDMarkdownEscaping                                         │
 │    Converts \-escaped single characters to UTF16-hex.       │
 │    e.g.  \*  →  \002a                                       │
-└─────────────────────────────────────────────────────────────┘
-│
-▼
-┌─────────────────────────────────────────────────────────────┐
-│  Phase 1.5 — REFERENCE DEFINITION EXTRACTION               │
-│                                                             │
-│  CDMarkdownLinkReference                                    │
-│    Strips [ref]: url lines from the string and populates    │
-│    CDMarkdownLinkReference.references with the mappings,   │
-│    so Phase 2 link reference parsing can resolve them.      │
 └─────────────────────────────────────────────────────────────┘
 │
 ▼
@@ -144,8 +147,8 @@ CDMarkdownElement                          Foundation
 └── Direct CDMarkdownElement implementations (no shared sub-protocol)
     ├── CDMarkdownTable          pipe-delimited GFM tables; writes per-cell paragraph attrs
     ├── CDMarkdownHorizontalRule matches ---, ***, ___ and replaces with styled rule character
-    ├── CDMarkdownCodeEscaping   UTF16-hex-encodes backtick span contents (Phase 1)
-    ├── CDMarkdownEscaping       UTF16-hex-encodes backslash-escaped chars (Phase 1)
+    ├── CDMarkdownCodeEscaping   UTF16-hex-encodes backtick span contents (Phase 1.5)
+    ├── CDMarkdownEscaping       UTF16-hex-encodes backslash-escaped chars (Phase 1.5)
     └── CDMarkdownUnescaping     reverses all remaining \HHHH sequences (Phase 3)
 ```
 

--- a/Source/CDMarkdownElement.swift
+++ b/Source/CDMarkdownElement.swift
@@ -90,7 +90,20 @@ public extension CDMarkdownElement {
                 match(regexMatch,
                       attributedString: attributedString)
                 let newLength = attributedString.length
-                location = regexMatch.range.location + regexMatch.range.length + newLength - oldLength
+                let nextLocation = regexMatch.range.location + regexMatch.range.length + newLength - oldLength
+                // A zero-length match combined with a match() that doesn't change the
+                // string's length would leave location unchanged, re-finding the same
+                // match forever. Force at least one character of forward progress. If
+                // that would push past the end of the string (a zero-length match can
+                // sit at the very last position, where there's no room left to search),
+                // stop instead of clamping: clamping to the end would leave location
+                // equal to the match's own start, letting a zero-width assertion there
+                // re-match forever just as before.
+                let advancedLocation = max(nextLocation, regexMatch.range.location + 1)
+                if advancedLocation > newLength {
+                    break
+                }
+                location = advancedLocation
             }
         } catch {}
     }

--- a/Source/CDMarkdownParser.swift
+++ b/Source/CDMarkdownParser.swift
@@ -454,7 +454,7 @@ open class CDMarkdownParser {
     /// leading-whitespace dedent step performs a full-string replacement that can collapse attribute-run boundaries.
     @available(*, deprecated, renamed: "parse(_:)")
     open func parse(_ markdown: NSAttributedString) -> NSAttributedString {
-        parse(markdown, loadImages: false)
+        runParsePipeline(markdown)
     }
 
     /// Asynchronously parses a Markdown string with image loading support.
@@ -481,7 +481,7 @@ open class CDMarkdownParser {
     /// leading-whitespace dedent step performs a full-string replacement that can collapse attribute-run boundaries.
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     open func parse(_ attributedString: NSAttributedString) async -> NSAttributedString {
-        let result = NSMutableAttributedString(attributedString: parse(attributedString, loadImages: false))
+        let result = NSMutableAttributedString(attributedString: runParsePipeline(attributedString))
         await resolveImages(in: result)
         return result
     }
@@ -597,7 +597,7 @@ open class CDMarkdownParser {
         return definitions
     }
 
-    private func parse(_ markdown: NSAttributedString, loadImages: Bool) -> NSAttributedString {
+    private func runParsePipeline(_ markdown: NSAttributedString) -> NSAttributedString {
         let attributedString = NSMutableAttributedString(attributedString: markdown)
         let mutableString = attributedString.mutableString
         if squashNewlines,
@@ -652,9 +652,7 @@ open class CDMarkdownParser {
         elements.append(contentsOf: unescapingElements)
 
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-            if !loadImages {
-                image.placeholderOnly = true
-            }
+            image.placeholderOnly = true
         #endif
 
         for element in elements {
@@ -664,9 +662,7 @@ open class CDMarkdownParser {
         }
 
         #if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
-            if !loadImages {
-                image.placeholderOnly = false
-            }
+            image.placeholderOnly = false
         #endif
 
         return attributedString

--- a/Source/Dictionary+CDMarkdownKit.swift
+++ b/Source/Dictionary+CDMarkdownKit.swift
@@ -54,7 +54,11 @@ internal extension Dictionary where Key == CDAttributedStringKey {
     }
 
     mutating func addStrikethroughStyle(_ strikethroughStyle: NSUnderlineStyle) {
-        self[NSAttributedString.Key.strikethroughStyle] = strikethroughStyle.rawValue as? Value
+        guard let value = strikethroughStyle.rawValue as? Value else {
+            assertionFailure("addStrikethroughStyle: Int rawValue could not bridge to \(Value.self)")
+            return
+        }
+        self[NSAttributedString.Key.strikethroughStyle] = value
     }
 
     mutating func addUnderlineColor(_ underlineColor: Value) {
@@ -62,6 +66,10 @@ internal extension Dictionary where Key == CDAttributedStringKey {
     }
 
     mutating func addUnderlineStyle(_ underlineStyle: NSUnderlineStyle) {
-        self[NSAttributedString.Key.underlineStyle] = underlineStyle.rawValue as? Value
+        guard let value = underlineStyle.rawValue as? Value else {
+            assertionFailure("addUnderlineStyle: Int rawValue could not bridge to \(Value.self)")
+            return
+        }
+        self[NSAttributedString.Key.underlineStyle] = value
     }
 }

--- a/Source/String+CDMarkdownKit.swift
+++ b/Source/String+CDMarkdownKit.swift
@@ -79,10 +79,6 @@ internal extension String {
         return from ..< to
     }
 
-    func characterCount() -> Int {
-        self.count
-    }
-
     func sizeWithAttributes(_ attributes: [CDAttributedStringKey: Any]? = nil) -> CGSize {
         #if os(macOS)
             return self.size(withAttributes: attributes)

--- a/Tests/CDMarkdownKitTests/Extensions/DictionaryCDMarkdownKitTests.swift
+++ b/Tests/CDMarkdownKitTests/Extensions/DictionaryCDMarkdownKitTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+@testable import CDMarkdownKit
+
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
+    import UIKit
+#elseif os(macOS)
+    import Cocoa
+#endif
+
+struct DictionaryCDMarkdownKitTests {
+
+    @Test func addStrikethroughStyleBridgesIntoAnyObjectDictionary() {
+        var attributes: [CDAttributedStringKey: AnyObject] = [:]
+        attributes.addStrikethroughStyle(.single)
+        let value = attributes[NSAttributedString.Key.strikethroughStyle] as? Int
+        #expect(value == NSUnderlineStyle.single.rawValue)
+    }
+
+    @Test func addUnderlineStyleBridgesIntoAnyObjectDictionary() {
+        var attributes: [CDAttributedStringKey: AnyObject] = [:]
+        attributes.addUnderlineStyle(.double)
+        let value = attributes[NSAttributedString.Key.underlineStyle] as? Int
+        #expect(value == NSUnderlineStyle.double.rawValue)
+    }
+}

--- a/Tests/CDMarkdownKitTests/Parser/CDMarkdownElementParseLoopTests.swift
+++ b/Tests/CDMarkdownKitTests/Parser/CDMarkdownElementParseLoopTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import CDMarkdownKit
+
+/// A CDMarkdownElement whose regex produces a zero-length match fixed at the position
+/// right after the leading "a", and whose match() never changes the string's length.
+/// This is the exact shape of custom element that can hang the default parse() loop
+/// if it doesn't force position to advance past zero-length matches: the lookbehind
+/// keeps matching the same position forever because nothing before it ever changes.
+///
+/// matchCount is capped as a runaway safety valve: if parse() isn't advancing past
+/// the zero-length match, this element deletes the leading "a" once the cap is hit,
+/// which removes the only anchor the lookbehind can match against. Deleting exactly
+/// one character strictly before the match's start (position 1) keeps the parse()
+/// loop's location arithmetic non-negative even under the unfixed, buggy formula,
+/// so a regression fails a bounded assertion instead of hanging or crashing.
+private final class ZeroLengthLookbehindElement: CDMarkdownElement {
+    let regex = "(?<=a)"
+    private(set) var matchCount = 0
+    private let matchCap = 50
+
+    func regularExpression() throws -> NSRegularExpression {
+        try NSRegularExpression(pattern: regex)
+    }
+
+    func match(_ result: NSTextCheckingResult,
+               attributedString: NSMutableAttributedString) {
+        matchCount += 1
+        if matchCount >= matchCap {
+            attributedString.deleteCharacters(in: NSRange(location: 0, length: 1))
+        }
+    }
+}
+
+extension ZeroLengthLookbehindElement: @unchecked Sendable {}
+
+/// A CDMarkdownElement whose regex produces a zero-length match only at the very end
+/// of the string (no character follows). Forcing the parse() loop's location forward
+/// by at least one past a zero-length match's start must not push location past the
+/// string's length, or the next search range becomes invalid (negative length).
+private final class ZeroLengthEndOfStringElement: CDMarkdownElement {
+    let regex = "(?!.)"
+    private(set) var matchCount = 0
+
+    func regularExpression() throws -> NSRegularExpression {
+        try NSRegularExpression(pattern: regex)
+    }
+
+    func match(_ result: NSTextCheckingResult,
+               attributedString: NSMutableAttributedString) {
+        matchCount += 1
+    }
+}
+
+extension ZeroLengthEndOfStringElement: @unchecked Sendable {}
+
+@MainActor
+struct CDMarkdownElementParseLoopTests {
+
+    @Test func parseLoopAdvancesPastZeroLengthMatches() {
+        // Given: "(?<=a)" matches only once, right after the leading "a".
+        let element = ZeroLengthLookbehindElement()
+        let attributedString = NSMutableAttributedString(string: "abb")
+
+        // When
+        element.parse(attributedString)
+
+        // Then: a correctly-advancing loop matches exactly once; a loop stuck
+        // re-matching the same position forever hits the safety cap instead.
+        #expect(element.matchCount == 1)
+    }
+
+    @Test func parseLoopHandlesZeroLengthMatchAtEndOfString() {
+        // Given: "(?!.)" matches only once, at the very end of "xyz".
+        let element = ZeroLengthEndOfStringElement()
+        let attributedString = NSMutableAttributedString(string: "xyz")
+
+        // When: this must not crash by searching an invalid negative-length range
+        // after forcing location one past the match's start.
+        element.parse(attributedString)
+
+        // Then
+        #expect(element.matchCount == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Removes dead `String.characterCount()` (zero call sites, and the one place that mattered used `.utf16.count` directly).
- Corrects CLAUDE.md/ARCHITECTURE.md's documented parsing-pipeline order: reference-definition extraction genuinely runs before escaping in `CDMarkdownParser.parse(_:loadImages:)`, not after as previously documented, and that order turns out to be the correct one (escaping first would UTF16-hex-encode escaped punctuation inside reference titles before the extraction regex ever saw it).
- Hardens the default `CDMarkdownElement.parse()` loop so a custom element whose regex can produce a zero-length match can no longer hang the parser indefinitely, with regression tests covering both a mid-string stuck position and a zero-length match at the very end of the string.
- Removes the dead `loadImages` parameter from the parser's private parse pipeline (both call sites always passed `false`); renamed the helper to `runParsePipeline(_:)` since dropping the parameter would otherwise collide with the public `parse(_:)` overload's identical signature.
- Makes `Dictionary.addStrikethroughStyle`/`addUnderlineStyle`'s `Int -> Value` bridging cast fail loudly via `assertionFailure` in debug builds instead of silently dropping the attribute, with regression tests locking in today's correct bridging behavior.

None of these change any public API or observable behavior for existing callers — all 255 tests pass, `swiftformat --lint` and `swiftlint --strict` are clean.

## Test plan
- [x] `swift test` — 255/255 passing (2 new test files added)
- [x] `swiftformat Source Tests --lint` — clean
- [x] `swiftlint --strict` — 0 violations
- [x] Verified the parse-loop fix against two crash-prone edge cases discovered during implementation (a mid-string stuck zero-length match, and one anchored at the very end of the string) before landing the final version

🤖 Generated with [Claude Code](https://claude.com/claude-code)